### PR TITLE
Reflect changes in version in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Pathetic
 
-A simple and intuitive 1.8-1.19 A* pathfinding API for Spigot & Paper plugins 
+A simple and intuitive 1.8-1.20 A* pathfinding API for Spigot & Paper plugins 
 
 ### How to import
 


### PR DESCRIPTION
Current Readme.MD shows versions 1.8-1.19 but pathetic supports 1.8-1.20.