### PR TITLE
Fixed NMS Interface for 1.20.6

### DIFF
--- a/pathetic-nms/src/main/java/org/patheloper/nms/NMSUtils.java
+++ b/pathetic-nms/src/main/java/org/patheloper/nms/NMSUtils.java
@@ -22,7 +22,7 @@ public class NMSUtils {
   public NMSUtils(int major, int minor) {
     switch (major) {
       case 20:
-        if (minor == 5) {
+        if (minor == 5 || minor == 6) {
           nmsInterface = new OneTwentyFourNMSInterface();
           break;
         } else if (minor == 3 || minor == 4) {


### PR DESCRIPTION
In 1.20.6 it would not load without the change because the API thinks it is not supported. The 1.20.6 is only a hotfix