### PR TITLE
Fixed bug with PlayerWalkableStrategy

### DIFF
--- a/pathetic-api/src/main/java/org/patheloper/api/pathing/strategy/strategies/PlayerWalkableStrategy.java
+++ b/pathetic-api/src/main/java/org/patheloper/api/pathing/strategy/strategies/PlayerWalkableStrategy.java
@@ -13,7 +13,7 @@ public class PlayerWalkableStrategy extends WalkablePathfinderStrategy {
     SnapshotManager snapshotManager = pathValidationContext.getSnapshotManager();
 
     if (snapshotManager.getBlock(pathPosition).isPassable()
-        && canStandOn(snapshotManager.getBlock(pathPosition.subtract(0, 1, 0)), snapshotManager)) {
+        && canStandOn(snapshotManager.getBlock(pathPosition), snapshotManager)) {
       return true;
     }
 


### PR DESCRIPTION
The ```canStandOn()``` function already substracts 1 from the y coordinate. Doing it in the ```PlayerWalkableStrategy``` again breaks the logic.