### PR TITLE
 Fixing compatibility with older versions.

### DIFF
--- a/pathetic-api/pom.xml
+++ b/pathetic-api/pom.xml
@@ -13,11 +13,6 @@
     <artifactId>pathetic-api</artifactId>
     <version>2.4.5</version>
 
-    <properties>
-        <maven.compiler.source>8</maven.compiler.source>
-        <maven.compiler.target>8</maven.compiler.target>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>org.spigotmc</groupId>

--- a/pathetic-mapping/pom.xml
+++ b/pathetic-mapping/pom.xml
@@ -12,11 +12,6 @@
     <artifactId>pathetic-mapping</artifactId>
     <version>2.4.5</version>
 
-    <properties>
-        <maven.compiler.source>8</maven.compiler.source>
-        <maven.compiler.target>8</maven.compiler.target>
-    </properties>
-
     <build>
         <plugins>
             <plugin>

--- a/pathetic-model/pom.xml
+++ b/pathetic-model/pom.xml
@@ -13,11 +13,6 @@
     <artifactId>pathetic-model</artifactId>
     <version>2.4.5</version>
 
-    <properties>
-        <maven.compiler.source>8</maven.compiler.source>
-        <maven.compiler.target>8</maven.compiler.target>
-    </properties>
-
     <build>
         <resources>
             <resource>

--- a/pathetic-model/src/main/java/org/patheloper/util/BukkitVersionUtil.java
+++ b/pathetic-model/src/main/java/org/patheloper/util/BukkitVersionUtil.java
@@ -4,6 +4,9 @@ import lombok.Getter;
 import lombok.experimental.UtilityClass;
 import org.bukkit.Bukkit;
 
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 @UtilityClass
 public class BukkitVersionUtil {
 
@@ -11,9 +14,25 @@ public class BukkitVersionUtil {
   private static final double CURRENT_MINOR;
 
   static {
-    String[] versionParts = Bukkit.getBukkitVersion().split("-")[0].split("\\.");
-    CURRENT_MAJOR = Double.parseDouble(versionParts[1]);
-    CURRENT_MINOR = versionParts.length >= 3 ? Double.parseDouble(versionParts[2]) : 0;
+    Pattern pattern = Pattern.compile(".*\\(.*MC.\\s*([a-zA-z0-9\\-.]+)\\s*\\)");
+    Matcher matcher = pattern.matcher(Bukkit.getVersion());
+
+    if (!matcher.matches() || matcher.group(1) == null) {
+      throw new IllegalStateException("Cannot parse version String '" + Bukkit.getVersion() + "'");
+    }
+
+    String[] elements = matcher.group(1).split("\\.");
+    if (elements.length < 1) {
+      throw new IllegalStateException("Invalid server version '" + matcher.group(1) + "'");
+    }
+
+    int[] values = new int[3];
+    for (int i = 0; i < Math.min(values.length, elements.length); i++) {
+      values[i] = Integer.parseInt(elements[i].trim());
+    }
+
+    CURRENT_MAJOR = values[1];
+    CURRENT_MINOR = values[2];
   }
 
   public static Version getVersion() {

--- a/pathetic-nms/paper/pom.xml
+++ b/pathetic-nms/paper/pom.xml
@@ -12,12 +12,6 @@
 
     <artifactId>paper</artifactId>
 
-    <properties>
-        <maven.compiler.source>18</maven.compiler.source>
-        <maven.compiler.target>18</maven.compiler.target>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    </properties>
-
     <repositories>
         <repository>
             <id>papermc</id>

--- a/pathetic-nms/pom.xml
+++ b/pathetic-nms/pom.xml
@@ -8,16 +8,11 @@
         <groupId>org.patheloper</groupId>
         <version>2.4.5</version>
     </parent>
+
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>pathetic-nms</artifactId>
     <version>2.4.5</version>
-
-    <properties>
-        <maven.compiler.source>8</maven.compiler.source>
-        <maven.compiler.target>8</maven.compiler.target>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    </properties>
 
     <dependencies>
         <dependency>

--- a/pathetic-nms/v1_12/pom.xml
+++ b/pathetic-nms/v1_12/pom.xml
@@ -12,12 +12,6 @@
 
     <artifactId>v1_12</artifactId>
 
-    <properties>
-        <maven.compiler.source>8</maven.compiler.source>
-        <maven.compiler.target>8</maven.compiler.target>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    </properties>
-
     <repositories>
         <repository>
             <id>codemc-repo</id>

--- a/pathetic-nms/v1_15/pom.xml
+++ b/pathetic-nms/v1_15/pom.xml
@@ -12,12 +12,6 @@
 
     <artifactId>v1_15</artifactId>
 
-    <properties>
-        <maven.compiler.source>8</maven.compiler.source>
-        <maven.compiler.target>8</maven.compiler.target>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    </properties>
-
     <repositories>
         <repository>
             <id>codemc-repo</id>

--- a/pathetic-nms/v1_16/pom.xml
+++ b/pathetic-nms/v1_16/pom.xml
@@ -12,12 +12,6 @@
 
     <artifactId>v1_16</artifactId>
 
-    <properties>
-        <maven.compiler.source>8</maven.compiler.source>
-        <maven.compiler.target>8</maven.compiler.target>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    </properties>
-
     <repositories>
         <repository>
             <id>codemc-repo</id>

--- a/pathetic-nms/v1_17/pom.xml
+++ b/pathetic-nms/v1_17/pom.xml
@@ -12,12 +12,6 @@
 
     <artifactId>v1_17</artifactId>
 
-    <properties>
-        <maven.compiler.source>8</maven.compiler.source>
-        <maven.compiler.target>8</maven.compiler.target>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    </properties>
-
     <repositories>
         <repository>
             <id>codemc-repo</id>

--- a/pathetic-nms/v1_18/pom.xml
+++ b/pathetic-nms/v1_18/pom.xml
@@ -12,12 +12,6 @@
 
     <artifactId>v1_18</artifactId>
 
-    <properties>
-        <maven.compiler.source>16</maven.compiler.source>
-        <maven.compiler.target>16</maven.compiler.target>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    </properties>
-
     <repositories>
         <repository>
             <id>codemc-repo</id>

--- a/pathetic-nms/v1_18_R2/pom.xml
+++ b/pathetic-nms/v1_18_R2/pom.xml
@@ -12,12 +12,6 @@
 
     <artifactId>v1_18_R2</artifactId>
 
-    <properties>
-        <maven.compiler.source>16</maven.compiler.source>
-        <maven.compiler.target>16</maven.compiler.target>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    </properties>
-
     <repositories>
         <repository>
             <id>codemc-repo</id>

--- a/pathetic-nms/v1_19_R2/pom.xml
+++ b/pathetic-nms/v1_19_R2/pom.xml
@@ -12,12 +12,6 @@
 
     <artifactId>v1_19_R2</artifactId>
 
-    <properties>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    </properties>
-
     <repositories>
         <repository>
             <id>codemc-repo</id>

--- a/pathetic-nms/v1_19_R3/pom.xml
+++ b/pathetic-nms/v1_19_R3/pom.xml
@@ -12,12 +12,6 @@
 
     <artifactId>v1_19_R3</artifactId>
 
-    <properties>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    </properties>
-
     <repositories>
         <repository>
             <id>codemc-repo</id>

--- a/pathetic-nms/v1_20_R1/pom.xml
+++ b/pathetic-nms/v1_20_R1/pom.xml
@@ -12,12 +12,6 @@
 
     <artifactId>v1_20_R1</artifactId>
 
-    <properties>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    </properties>
-
     <repositories>
         <repository>
             <id>codemc-repo</id>

--- a/pathetic-nms/v1_20_R2/pom.xml
+++ b/pathetic-nms/v1_20_R2/pom.xml
@@ -12,12 +12,6 @@
 
     <artifactId>v1_20_R2</artifactId>
 
-    <properties>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    </properties>
-
     <repositories>
         <repository>
             <id>codemc-repo</id>

--- a/pathetic-nms/v1_20_R3/pom.xml
+++ b/pathetic-nms/v1_20_R3/pom.xml
@@ -12,12 +12,6 @@
 
     <artifactId>v1_20_R3</artifactId>
 
-    <properties>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    </properties>
-
     <repositories>
         <repository>
             <id>codemc-repo</id>

--- a/pathetic-nms/v1_20_R4/pom.xml
+++ b/pathetic-nms/v1_20_R4/pom.xml
@@ -12,12 +12,6 @@
 
     <artifactId>v1_20_R4</artifactId>
 
-    <properties>
-        <maven.compiler.source>21</maven.compiler.source>
-        <maven.compiler.target>21</maven.compiler.target>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    </properties>
-
     <repositories>
         <repository>
             <id>codemc-repo</id>

--- a/pathetic-nms/v1_21/pom.xml
+++ b/pathetic-nms/v1_21/pom.xml
@@ -12,12 +12,6 @@
 
     <artifactId>v1_21</artifactId>
 
-    <properties>
-        <maven.compiler.source>21</maven.compiler.source>
-        <maven.compiler.target>21</maven.compiler.target>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    </properties>
-
     <repositories>
         <repository>
             <id>codemc-repo</id>

--- a/pathetic-nms/v1_8/pom.xml
+++ b/pathetic-nms/v1_8/pom.xml
@@ -12,12 +12,6 @@
 
     <artifactId>v1_8</artifactId>
 
-    <properties>
-        <maven.compiler.source>8</maven.compiler.source>
-        <maven.compiler.target>8</maven.compiler.target>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    </properties>
-
     <repositories>
         <repository>
             <id>codemc-repo</id>

--- a/pom.xml
+++ b/pom.xml
@@ -12,6 +12,7 @@
     <properties>
         <maven.compiler.source>8</maven.compiler.source>
         <maven.compiler.target>8</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <modules>


### PR DESCRIPTION
This PR performs a backward compatibility fix.

In older versions, the method for obtaining the server version did not work, as it threw an index out of bounds when it was obtained. This PR implements a more consistent way of obtaining the server version from the code in this project [here](https://github.com/lucko/helper/blob/master/helper/src/main/java/me/lucko/helper/reflect/MinecraftVersions.java#L139).

Another error was with classes not supported for older java, because they were compiled with more recent versions. Specifically the PatheticMapper class as shown in the image.

![error](https://i.imgur.com/cFp2tUw.png)

Centralize all maven compatibility properties (source and target) only in the parent project to prevent child projects from having compatibility with different versions of java.

**NOTE**: Only tested on version 1.8.9, tests for other versions may be necessary.