### PR TITLE
feat: introduce abort method for immediate pathfinding termination an…

### DIFF
--- a/pathetic-api/src/main/java/org/patheloper/api/pathing/Pathfinder.java
+++ b/pathetic-api/src/main/java/org/patheloper/api/pathing/Pathfinder.java
@@ -24,4 +24,12 @@ public interface Pathfinder {
   @NonNull
   CompletionStage<PathfinderResult> findPath(
       @NonNull PathPosition start, @NonNull PathPosition target, @Nullable List<@NonNull PathFilter> filters);
+
+  /**
+   * Aborts the running pathfinding process.
+   * <p>
+   * In this context aborts means that the pathfinding process will be stopped and the result will
+   * be {@link org.patheloper.api.pathing.result.PathState#ABORTED}.
+   */
+  void abort();
 }

--- a/pathetic-api/src/main/java/org/patheloper/api/pathing/result/PathState.java
+++ b/pathetic-api/src/main/java/org/patheloper/api/pathing/result/PathState.java
@@ -2,6 +2,8 @@ package org.patheloper.api.pathing.result;
 
 public enum PathState {
 
+  /** The pathfinding process was aborted */
+  ABORTED,
   /** Pathing failed to start, typically due to an invalid start or end position. */
   INITIALLY_FAILED,
   /** The Path was successfully found */

--- a/pathetic-model/src/main/java/org/patheloper/model/pathing/pathfinder/Depth.java
+++ b/pathetic-model/src/main/java/org/patheloper/model/pathing/pathfinder/Depth.java
@@ -1,0 +1,17 @@
+package org.patheloper.model.pathing.pathfinder;
+
+import lombok.Getter;
+
+@Getter
+public class Depth {
+
+  private int depth;
+
+  public Depth(int depth) {
+    this.depth = depth;
+  }
+
+  public void increment() {
+    depth++;
+  }
+}


### PR DESCRIPTION
…d result return

Refactored the Pathfinder classes to include a new `abort()` method, enabling immediate termination of the pathfinding process and returning the current result. Additionally, the specific Pathfinder implementation has been refactored to operate in a tick-wise manner.