### PR TITLE
[3.2] SnapshotManager#getHighestBlockAt, PathValidationContext now holds the absolute start and target and bStats can now be deactivated

### DIFF
--- a/pathetic-api/pom.xml
+++ b/pathetic-api/pom.xml
@@ -7,11 +7,11 @@
     <parent>
         <artifactId>pathetic-main</artifactId>
         <groupId>org.patheloper</groupId>
-        <version>3.1.1</version>
+        <version>3.2</version>
     </parent>
 
     <artifactId>pathetic-api</artifactId>
-    <version>3.1.1</version>
+    <version>3.2</version>
 
     <dependencies>
         <dependency>

--- a/pathetic-api/src/main/java/org/patheloper/api/event/package-info.java
+++ b/pathetic-api/src/main/java/org/patheloper/api/event/package-info.java
@@ -28,7 +28,7 @@
  *  // Define a listener for the new event
  *  public class CustomEventListener {
  *
- *   @Subscribe
+ *   {@literal @}Subscribe
  *   public void onCustomEvent(CustomEvent event) {
  *     System.out.println("Received custom event with message: " + event.getMessage());
  *    }

--- a/pathetic-api/src/main/java/org/patheloper/api/event/package-info.java
+++ b/pathetic-api/src/main/java/org/patheloper/api/event/package-info.java
@@ -11,32 +11,33 @@
  *
  * <p>For example:
  *
- * <pre>
+ * <pre>{@code
  * // Define a new event
- * public class CustomEvent extends PathingEvent {
- *     private final String message;
+ *  public class CustomEvent extends PathingEvent {
+ *    private final String message;
  *
- *     public CustomEvent(String message) {
- *         this.message = message;
- *     }
+ *    public CustomEvent(String message) {
+ *      this.message = message;
+ *    }
  *
- *     public String getMessage() {
- *         return message;
- *     }
- * }
+ *    public String getMessage() {
+ *      return message;
+ *    }
+ *  }
  *
- * // Define a listener for the new event
- * public class CustomEventListener {
+ *  // Define a listener for the new event
+ *  public class CustomEventListener {
  *
- *     @Subscribe
- *     public void onCustomEvent(CustomEvent event) {
- *         System.out.println("Received custom event with message: " + event.getMessage());
- *     }
- * }
+ *   @Subscribe
+ *   public void onCustomEvent(CustomEvent event) {
+ *     System.out.println("Received custom event with message: " + event.getMessage());
+ *    }
+ *  }
  *
  * // Register the listener and raise the event
  * EventPublisher.registerListener(new CustomEventListener());
  * EventPublisher.raiseEvent(new CustomEvent("Hello, world!"));
- * </pre>
+ *
+ * }</pre>
  */
 package org.patheloper.api.event;

--- a/pathetic-api/src/main/java/org/patheloper/api/pathing/configuration/PathfinderConfiguration.java
+++ b/pathetic-api/src/main/java/org/patheloper/api/pathing/configuration/PathfinderConfiguration.java
@@ -78,14 +78,15 @@ public class PathfinderConfiguration {
    * instead of filtering. This means that the pathfinding algorithm will prioritize paths that pass
    * the filters over paths that do not.
    *
-   * <p>Setting this to true will no longer take the {@link org.patheloper.api.pathing.filter.PathFilterStage}s into the validation
-   * process. Shared filters must still be passed.
+   * <p>Setting this to true will no longer take the {@link
+   * org.patheloper.api.pathing.filter.PathFilterStage}s into the validation process. Shared filters
+   * must still be passed.
    *
    * <p>{@link Pathfinder#findPath(PathPosition, PathPosition, List, List)}
+   *
    * @experimental This feature is experimental and may be subject to change.
    */
-  @Experimental
-  @Builder.Default boolean prioritizing = false;
+  @Experimental @Builder.Default boolean prioritizing = false;
 
   /**
    * The set of weights used to calculate heuristics within the A* algorithm. These influence the
@@ -94,6 +95,16 @@ public class PathfinderConfiguration {
    * @default HeuristicWeights.NATURAL_PATH_WEIGHTS
    */
   @Builder.Default HeuristicWeights heuristicWeights = HeuristicWeights.NATURAL_PATH_WEIGHTS;
+
+  /**
+   * Determines whether the pathfinding algorithm should collect statistics about the pathfinding
+   * process. This can be useful for debugging and performance tuning.
+   *
+   * <p>Help us improve the API by providing feedback with the collected statistics!
+   *
+   * @default true
+   */
+  @Builder.Default boolean bStats = true;
 
   /**
    * @return A new {@link PathfinderConfiguration} with default parameters but async.

--- a/pathetic-api/src/main/java/org/patheloper/api/pathing/filter/PathValidationContext.java
+++ b/pathetic-api/src/main/java/org/patheloper/api/pathing/filter/PathValidationContext.java
@@ -4,11 +4,45 @@ import lombok.Value;
 import org.patheloper.api.snapshot.SnapshotManager;
 import org.patheloper.api.wrapper.PathPosition;
 
-/** A parameter object for the {@link PathFilter#filter} method. */
+/**
+ * PathValidationContext is a data container used during the pathfinding process to provide relevant
+ * contextual information needed for evaluating path validity.
+ *
+ * <p>This context is passed to {@link PathFilter#filter} methods during the pathfinding process and
+ * allows filters to validate or invalidate nodes based on the provided context.
+ */
 @Value
 public class PathValidationContext {
 
+  /**
+   * The current position being evaluated in the pathfinding process. This represents the position
+   * that is being validated by the filter to determine if it can be part of a valid path.
+   */
   PathPosition position;
+
+  /**
+   * The parent position of the current position. This is the previous node from which the current
+   * position was reached. It is used to trace the path and ensure logical continuity between nodes.
+   */
   PathPosition parent;
+
+  /**
+   * The absolute start position of the pathfinding process. This represents the original starting
+   * point of the path and remains constant throughout the algorithm, providing a stable reference.
+   */
+  PathPosition absoluteStart;
+
+  /**
+   * The absolute target position of the pathfinding process. This is the final goal or destination
+   * that the pathfinding algorithm is trying to reach. Like the start, it remains constant and
+   * provides a clear end-point for the path.
+   */
+  PathPosition absoluteTarget;
+
+  /**
+   * The snapshot manager provides access to world data, such as block information, in the context
+   * of the pathfinding process. It is used to retrieve block data from the world at different
+   * positions during path validation.
+   */
   SnapshotManager snapshotManager;
 }

--- a/pathetic-api/src/main/java/org/patheloper/api/snapshot/SnapshotManager.java
+++ b/pathetic-api/src/main/java/org/patheloper/api/snapshot/SnapshotManager.java
@@ -18,4 +18,14 @@ public interface SnapshotManager {
    * @return {@link PathBlock} the block.
    */
   PathBlock getBlock(PathPosition position);
+
+  /**
+   * Gets the highest block at the given position
+   *
+   * @api.Note If the pathfinder is not permitted to load chunks, this method will return null if
+   *     the chunk is not loaded.
+   * @param position the position to get as block-form
+   * @return {@link PathBlock} the block.
+   */
+  PathBlock getHighestBlockAt(PathPosition position);
 }

--- a/pathetic-example/pom.xml
+++ b/pathetic-example/pom.xml
@@ -7,11 +7,11 @@
     <parent>
         <artifactId>pathetic-main</artifactId>
         <groupId>org.patheloper</groupId>
-        <version>3.1.1</version>
+        <version>3.2</version>
     </parent>
 
     <artifactId>pathetic-example</artifactId>
-    <version>3.1.1</version>
+    <version>3.2</version>
     <packaging>jar</packaging>
 
     <name>PatheticTest</name>
@@ -73,7 +73,7 @@
         <dependency>
             <groupId>org.patheloper</groupId>
             <artifactId>pathetic-mapping</artifactId>
-            <version>3.1.1</version>
+            <version>3.2</version>
         </dependency>
     </dependencies>
 </project>

--- a/pathetic-mapping/pom.xml
+++ b/pathetic-mapping/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <artifactId>pathetic-main</artifactId>
         <groupId>org.patheloper</groupId>
-        <version>3.1.1</version>
+        <version>3.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>pathetic-mapping</artifactId>
-    <version>3.1.1</version>
+    <version>3.2</version>
 
     <build>
         <plugins>
@@ -34,7 +34,7 @@
         <dependency>
             <groupId>org.patheloper</groupId>
             <artifactId>pathetic-model</artifactId>
-            <version>3.1.1</version>
+            <version>3.2</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/pathetic-model/pom.xml
+++ b/pathetic-model/pom.xml
@@ -6,11 +6,11 @@
     <parent>
         <artifactId>pathetic-main</artifactId>
         <groupId>org.patheloper</groupId>
-        <version>3.1.1</version>
+        <version>3.2</version>
     </parent>
 
     <artifactId>pathetic-model</artifactId>
-    <version>3.1.1</version>
+    <version>3.2</version>
 
     <build>
         <resources>
@@ -100,13 +100,13 @@
         <dependency>
             <groupId>org.patheloper</groupId>
             <artifactId>pathetic-api</artifactId>
-            <version>3.1.1</version>
+            <version>3.2</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.patheloper</groupId>
             <artifactId>pathetic-nms</artifactId>
-            <version>3.1.1</version>
+            <version>3.2</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/pathetic-model/src/main/java/org/patheloper/BStatsHandler.java
+++ b/pathetic-model/src/main/java/org/patheloper/BStatsHandler.java
@@ -9,10 +9,14 @@ import org.bukkit.plugin.java.JavaPlugin;
 @UtilityClass
 public class BStatsHandler {
 
+  private Metrics metrics;
+
   private int paths;
 
-  public void init(JavaPlugin javaPlugin) {
-    Metrics metrics = new Metrics(javaPlugin, 20529);
+  private void init(JavaPlugin javaPlugin) {
+    if (metrics != null) return;
+
+    metrics = new Metrics(javaPlugin, 20529);
     metrics.addCustomChart(
         new SingleLineChart(
             "total_paths",
@@ -24,7 +28,15 @@ public class BStatsHandler {
     metrics.addCustomChart(new SimplePie("pathetic-model_version", Pathetic::getModelVersion));
   }
 
+  private void makeSureBStatsIsInitialized() {
+    if (!Pathetic.isInitialized())
+      throw new IllegalStateException("Pathetic has not been initialized yet");
+
+    init(Pathetic.getPluginInstance());
+  }
+
   public synchronized void increasePathCount() {
+    makeSureBStatsIsInitialized();
     paths++;
   }
 }

--- a/pathetic-model/src/main/java/org/patheloper/Pathetic.java
+++ b/pathetic-model/src/main/java/org/patheloper/Pathetic.java
@@ -35,8 +35,6 @@ public class Pathetic {
     instance = javaPlugin;
     Bukkit.getPluginManager().registerEvents(new ChunkInvalidateListener(), javaPlugin);
 
-    BStatsHandler.init(javaPlugin);
-
     loadModelVersion();
 
     if (BukkitVersionUtil.getVersion().isUnder(16, 0)

--- a/pathetic-model/src/main/java/org/patheloper/model/pathing/pathfinder/AStarPathfinder.java
+++ b/pathetic-model/src/main/java/org/patheloper/model/pathing/pathfinder/AStarPathfinder.java
@@ -89,6 +89,8 @@ public class AStarPathfinder extends AbstractPathfinder {
               new PathValidationContext(
                   node.getPosition(),
                   node.getParent() != null ? node.getParent().getPosition() : null,
+                  node.getStart(),
+                  node.getTarget(),
                   snapshotManager));
 
       if (filterResult) {
@@ -248,6 +250,8 @@ public class AStarPathfinder extends AbstractPathfinder {
           new PathValidationContext(
               node.getPosition(),
               node.getParent() != null ? node.getParent().getPosition() : null,
+              node.getStart(),
+              node.getTarget(),
               snapshotManager);
 
       if (!filter.filter(context)) {
@@ -265,6 +269,8 @@ public class AStarPathfinder extends AbstractPathfinder {
           new PathValidationContext(
               node.getPosition(),
               node.getParent() != null ? node.getParent().getPosition() : null,
+              node.getStart(),
+              node.getTarget(),
               snapshotManager))) {
         return true;
       }

--- a/pathetic-model/src/main/java/org/patheloper/model/pathing/pathfinder/AbstractPathfinder.java
+++ b/pathetic-model/src/main/java/org/patheloper/model/pathing/pathfinder/AbstractPathfinder.java
@@ -157,7 +157,7 @@ abstract class AbstractPathfinder implements Pathfinder {
       PathPosition target,
       List<PathFilter> filters,
       List<PathFilterStage> filterStages) {
-    BStatsHandler.increasePathCount();
+    pushToBStatsIfActivated();
     return pathfinderConfiguration.isAsync()
         ? CompletableFuture.supplyAsync(
                 () -> executePathingAndCleanupFilters(start, target, filters, filterStages),
@@ -165,6 +165,12 @@ abstract class AbstractPathfinder implements Pathfinder {
             .thenApply(this::finishPathing)
             .exceptionally(throwable -> handleException(start, target, throwable))
         : initiateSyncPathing(start, target, filters, filterStages);
+  }
+
+  private void pushToBStatsIfActivated() {
+    if (pathfinderConfiguration.isBStats()) {
+      BStatsHandler.increasePathCount();
+    }
   }
 
   private PathfinderResult executePathing(

--- a/pathetic-model/src/main/java/org/patheloper/model/snapshot/FailingSnapshotManager.java
+++ b/pathetic-model/src/main/java/org/patheloper/model/snapshot/FailingSnapshotManager.java
@@ -128,8 +128,8 @@ public class FailingSnapshotManager implements SnapshotManager {
     if (chunkSnapshotOptional.isPresent()) {
       ChunkSnapshot chunkSnapshot = chunkSnapshotOptional.get();
 
-      int chunkX = position.getBlockX() >> 4;
-      int chunkZ = position.getBlockZ() >> 4;
+      int chunkX = position.getBlockX() & 0xF;
+      int chunkZ = position.getBlockZ() & 0xF;
 
       int highestY = chunkSnapshot.getHighestBlockYAt(chunkX, chunkZ);
 
@@ -214,8 +214,8 @@ public class FailingSnapshotManager implements SnapshotManager {
     private PathBlock ensureHighestBlock(PathPosition pathPosition) {
       ChunkSnapshot chunkSnapshot = retrieveSnapshot(pathPosition);
 
-      int chunkX = pathPosition.getBlockX() >> 4;
-      int chunkZ = pathPosition.getBlockZ() >> 4;
+      int chunkX = pathPosition.getBlockX() & 0xF;
+      int chunkZ = pathPosition.getBlockZ() & 0xF;
 
       int highestY = chunkSnapshot.getHighestBlockYAt(chunkX, chunkZ);
 

--- a/pathetic-model/src/main/java/org/patheloper/model/snapshot/FailingSnapshotManager.java
+++ b/pathetic-model/src/main/java/org/patheloper/model/snapshot/FailingSnapshotManager.java
@@ -21,6 +21,20 @@ import org.patheloper.util.BukkitVersionUtil;
 import org.patheloper.util.ChunkUtils;
 import org.patheloper.util.ErrorLogger;
 
+/**
+ * The FailingSnapshotManager class implements the SnapshotManager interface and provides a default
+ * implementation for retrieving block data snapshots from a Minecraft world. It utilizes chunk
+ * snapshots to efficiently access block information, even in asynchronous contexts.
+ *
+ * <p>FailingSnapshotManager also uses NMS (net.minecraft.server) utilities to bypass the Spigot
+ * AsyncCatcher and fetch snapshots natively from an asynchronous context. This allows for more
+ * flexible and efficient access to world data.
+ *
+ * <p>Note: While this manager is designed to efficiently retrieve block data snapshots, it may
+ * encounter failures or null results if the pathfinder is not permitted to load chunks or if chunks
+ * are not loaded in the world. Developers using this manager should handle potential failures
+ * gracefully.
+ */
 public class FailingSnapshotManager implements SnapshotManager {
 
   private static final Map<UUID, WorldDomain> SNAPSHOTS_MAP = new ConcurrentHashMap<>();
@@ -135,6 +149,11 @@ public class FailingSnapshotManager implements SnapshotManager {
     return null;
   }
 
+  /**
+   * The RequestingSnapshotManager is an inner class of FailingSnapshotManager, extending it. This
+   * class provides additional functionality for ensuring that block data snapshots are available,
+   * even if not initially loaded.
+   */
   public static class RequestingSnapshotManager extends FailingSnapshotManager {
 
     private static ChunkSnapshot retrieveChunkSnapshot(

--- a/pathetic-model/src/main/java/org/patheloper/model/snapshot/FailingSnapshotManager.java
+++ b/pathetic-model/src/main/java/org/patheloper/model/snapshot/FailingSnapshotManager.java
@@ -129,8 +129,8 @@ public class FailingSnapshotManager implements SnapshotManager {
     if (chunkSnapshotOptional.isPresent()) {
       ChunkSnapshot chunkSnapshot = chunkSnapshotOptional.get();
 
-      int chunkX = position.getBlockX() & 0xF;
-      int chunkZ = position.getBlockZ() & 0xF;
+      int chunkX = position.getBlockX() >> 4;
+      int chunkZ = position.getBlockZ() >> 4;
 
       for (int y = chunkSnapshot.getHighestBlockYAt(chunkX, chunkZ);
           y >= position.getPathEnvironment().getMinHeight();
@@ -219,8 +219,8 @@ public class FailingSnapshotManager implements SnapshotManager {
     private PathBlock ensureHighestBlock(PathPosition pathPosition) {
       ChunkSnapshot chunkSnapshot = retrieveSnapshot(pathPosition);
 
-      int chunkX = pathPosition.getBlockX() & 0xF;
-      int chunkZ = pathPosition.getBlockZ() & 0xF;
+      int chunkX = pathPosition.getBlockX() >> 4;
+      int chunkZ = pathPosition.getBlockZ() >> 4;
 
       int minY = pathPosition.getPathEnvironment().getMinHeight();
       for (int y = chunkSnapshot.getHighestBlockYAt(chunkX, chunkZ); y >= minY; y--) {

--- a/pathetic-model/src/main/java/org/patheloper/model/snapshot/FailingSnapshotManager.java
+++ b/pathetic-model/src/main/java/org/patheloper/model/snapshot/FailingSnapshotManager.java
@@ -132,10 +132,12 @@ public class FailingSnapshotManager implements SnapshotManager {
       int chunkX = position.getBlockX() & 0xF;
       int chunkZ = position.getBlockZ() & 0xF;
 
-      for (int y = chunkSnapshot.getHighestBlockYAt(chunkX, chunkZ); y >= 0; y--) {
+      for (int y = chunkSnapshot.getHighestBlockYAt(chunkX, chunkZ);
+          y >= position.getPathEnvironment().getMinHeight();
+          y--) {
         Material material = chunkSnapshot.getBlockType(chunkX, y, chunkZ);
 
-        if (!material.isAir() && material.isSolid()) {
+        if (!material.isAir()) {
           PathPosition highestBlockPosition =
               new PathPosition(
                   position.getPathEnvironment(), position.getBlockX(), y, position.getBlockZ());
@@ -148,7 +150,7 @@ public class FailingSnapshotManager implements SnapshotManager {
       }
     }
 
-    // If no solid block was found or the chunk snapshot wasn't present
+    // If no non-air block was found or the chunk snapshot wasn't present
     return null;
   }
 
@@ -220,10 +222,11 @@ public class FailingSnapshotManager implements SnapshotManager {
       int chunkX = pathPosition.getBlockX() & 0xF;
       int chunkZ = pathPosition.getBlockZ() & 0xF;
 
-      for (int y = chunkSnapshot.getHighestBlockYAt(chunkX, chunkZ); y >= 0; y--) {
+      int minY = pathPosition.getPathEnvironment().getMinHeight();
+      for (int y = chunkSnapshot.getHighestBlockYAt(chunkX, chunkZ); y >= minY; y--) {
         Material material = ChunkUtils.getMaterial(chunkSnapshot, chunkX, y, chunkZ);
 
-        if (!material.isAir() && material.isSolid()) {
+        if (!material.isAir()) {
           BlockState blockState =
               CHUNK_DATA_PROVIDER_RESOLVER
                   .getChunkDataProvider()
@@ -240,7 +243,7 @@ public class FailingSnapshotManager implements SnapshotManager {
         }
       }
 
-      // If no solid block is found
+      // If no non-air block was found
       return null;
     }
   }

--- a/pathetic-nms/paper/pom.xml
+++ b/pathetic-nms/paper/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.patheloper</groupId>
         <artifactId>pathetic-main</artifactId>
-        <version>3.1.1</version>
+        <version>3.2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>org.patheloper</groupId>
             <artifactId>pathetic-api</artifactId>
-            <version>3.1.1</version>
+            <version>3.2</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/pathetic-nms/pom.xml
+++ b/pathetic-nms/pom.xml
@@ -6,13 +6,13 @@
     <parent>
         <artifactId>pathetic-main</artifactId>
         <groupId>org.patheloper</groupId>
-        <version>3.1.1</version>
+        <version>3.2</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>pathetic-nms</artifactId>
-    <version>3.1.1</version>
+    <version>3.2</version>
 
     <dependencies>
         <dependency>
@@ -33,49 +33,49 @@
         <dependency>
             <groupId>org.patheloper</groupId>
             <artifactId>paper</artifactId>
-            <version>3.1.1</version>
+            <version>3.2</version>
             <scope>compile</scope>
         </dependency>
 
         <dependency>
             <groupId>org.patheloper</groupId>
             <artifactId>v1_18Up</artifactId>
-            <version>3.1.1</version>
+            <version>3.2</version>
             <scope>compile</scope>
         </dependency>
 
         <dependency>
             <groupId>org.patheloper</groupId>
             <artifactId>v1_17</artifactId>
-            <version>3.1.1</version>
+            <version>3.2</version>
             <scope>compile</scope>
         </dependency>
 
         <dependency>
             <groupId>org.patheloper</groupId>
             <artifactId>v1_16</artifactId>
-            <version>3.1.1</version>
+            <version>3.2</version>
             <scope>compile</scope>
         </dependency>
 
         <dependency>
             <groupId>org.patheloper</groupId>
             <artifactId>v1_15</artifactId>
-            <version>3.1.1</version>
+            <version>3.2</version>
             <scope>compile</scope>
         </dependency>
 
         <dependency>
             <groupId>org.patheloper</groupId>
             <artifactId>v1_12</artifactId>
-            <version>3.1.1</version>
+            <version>3.2</version>
             <scope>compile</scope>
         </dependency>
 
         <dependency>
             <groupId>org.patheloper</groupId>
             <artifactId>v1_8</artifactId>
-            <version>3.1.1</version>
+            <version>3.2</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/pathetic-nms/v1_12/pom.xml
+++ b/pathetic-nms/v1_12/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>pathetic-main</artifactId>
         <groupId>org.patheloper</groupId>
-        <version>3.1.1</version>
+        <version>3.2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/pathetic-nms/v1_15/pom.xml
+++ b/pathetic-nms/v1_15/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>pathetic-main</artifactId>
         <groupId>org.patheloper</groupId>
-        <version>3.1.1</version>
+        <version>3.2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/pathetic-nms/v1_16/pom.xml
+++ b/pathetic-nms/v1_16/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>pathetic-main</artifactId>
         <groupId>org.patheloper</groupId>
-        <version>3.1.1</version>
+        <version>3.2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/pathetic-nms/v1_17/pom.xml
+++ b/pathetic-nms/v1_17/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>pathetic-main</artifactId>
         <groupId>org.patheloper</groupId>
-        <version>3.1.1</version>
+        <version>3.2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/pathetic-nms/v1_18Up/pom.xml
+++ b/pathetic-nms/v1_18Up/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.patheloper</groupId>
         <artifactId>pathetic-main</artifactId>
-        <version>3.1.1</version>
+        <version>3.2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/pathetic-nms/v1_8/pom.xml
+++ b/pathetic-nms/v1_8/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>pathetic-main</artifactId>
         <groupId>org.patheloper</groupId>
-        <version>3.1.1</version>
+        <version>3.2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.10.0</version>
+                <version>3.10.1</version>
                 <configuration>
                     <reportOutputDirectory>${project.reporting.outputDirectory}/myoutput</reportOutputDirectory>
                     <destDir>myapidocs</destDir>
@@ -87,7 +87,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.10.0</version>
+                <version>3.10.1</version>
                 <configuration>
                     <source>8</source>
                     <reportOutputDirectory>../</reportOutputDirectory>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>org.patheloper</groupId>
     <artifactId>pathetic-main</artifactId>
     <packaging>pom</packaging>
-    <version>3.1.1</version>
+    <version>3.2</version>
 
     <properties>
         <maven.compiler.source>8</maven.compiler.source>
@@ -74,7 +74,7 @@
             <dependency>
                 <groupId>org.patheloper</groupId>
                 <artifactId>pathetic-api</artifactId>
-                <version>3.1.1</version>
+                <version>3.2</version>
                 <scope>provided</scope>
             </dependency>
         </dependencies>


### PR DESCRIPTION
^