### PR TITLE
Bugfix: Examined Positions

### DIFF
--- a/.github/workflows/attach_jar.yml
+++ b/.github/workflows/attach_jar.yml
@@ -41,7 +41,7 @@ jobs:
           mvn -U -V -e -B -ntp clean install compile package -pl pathetic-bukkit/pathetic-example -amd -DskipTests
 
       - name: Upload Pathetic-Example
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: pathetic-example
           path: D:\a\pathetic\pathetic\pathetic-bukkit\pathetic-example\target\pathetic-example.jar

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,7 +62,7 @@ jobs:
 
       - name: Upload Example Jar
         if: fromJSON(steps.determine.outputs.result).action == 'jar'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: pathetic-${{ fromJSON(steps.determine.outputs.result).pr }}
           path: pathetic-bukkit/pathetic-example/target/pathetic-example.jar

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 Benjamin Sommerfeld
+Copyright (c) 2025 Benjamin Sommerfeld
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/pathetic-api/pom.xml
+++ b/pathetic-api/pom.xml
@@ -7,9 +7,9 @@
     <parent>
         <artifactId>pathetic-main</artifactId>
         <groupId>de.metaphoriker</groupId>
-        <version>4.0</version>
+        <version>4.0.1</version>
     </parent>
 
     <artifactId>pathetic-api</artifactId>
-    <version>4.0</version>
+    <version>4.0.1</version>
 </project>

--- a/pathetic-api/src/main/java/de/metaphoriker/pathetic/api/pathing/configuration/HeuristicWeights.java
+++ b/pathetic-api/src/main/java/de/metaphoriker/pathetic/api/pathing/configuration/HeuristicWeights.java
@@ -27,30 +27,12 @@ public final class HeuristicWeights {
    */
   public static final HeuristicWeights DIRECT_PATH_WEIGHTS = create(0.6, 0.3, 0.0, 0.1);
 
-  /**
-   * The weight applied to the Manhattan distance component of the heuristic. A higher weight
-   * favours paths with a greater emphasis on direct, axis-aligned movement.
-   */
   private final double manhattanWeight;
 
-  /**
-   * The weight applied to the Octile distance component of the heuristic. A higher weight allows
-   * diagonal movement, enabling more flexible paths in 3D environments.
-   */
   private final double octileWeight;
 
-  /**
-   * The weight applied to the perpendicular distance component of the heuristic. Increased weight
-   * discourages deviations from the straight line between the start and target, resulting in
-   * smoother paths.
-   */
   private final double perpendicularWeight;
 
-  /**
-   * The weight applied to the height difference (elevation change) component of the heuristic. A
-   * higher weight gives more consideration to vertical distance, important for terrains with
-   * varying verticality.
-   */
   private final double heightWeight;
 
   private HeuristicWeights(
@@ -64,6 +46,21 @@ public final class HeuristicWeights {
     this.heightWeight = heightWeight;
   }
 
+  /**
+   * Creates a new {@code HeuristicWeights} instance with the specified weights.
+   *
+   * @param manhattanWeight The weight applied to the Manhattan distance component. A higher weight
+   *     favours paths with a greater emphasis on direct, axis-aligned movement.
+   * @param octileWeight The weight applied to the Octile distance component. A higher weight allows
+   *     diagonal movement, enabling more flexible paths in 3D environments.
+   * @param perpendicularWeight The weight applied to the perpendicular distance component.
+   *     Increased weight discourages deviations from the straight line between the start and
+   *     target, resulting in smoother paths.
+   * @param heightWeight The weight applied to the height difference (elevation change) component. A
+   *     higher weight gives more consideration to vertical distance, important for terrains with
+   *     varying verticality.
+   * @return A new {@code HeuristicWeights} instance with the given weights.
+   */
   public static HeuristicWeights create(
       double manhattanWeight,
       double octileWeight,
@@ -72,18 +69,39 @@ public final class HeuristicWeights {
     return new HeuristicWeights(manhattanWeight, octileWeight, perpendicularWeight, heightWeight);
   }
 
+  /**
+   * Returns the weight applied to the Manhattan distance component of the heuristic.
+   *
+   * @return The Manhattan distance weight.
+   */
   public double getManhattanWeight() {
     return this.manhattanWeight;
   }
 
+  /**
+   * Returns the weight applied to the Octile distance component of the heuristic.
+   *
+   * @return The Octile distance weight.
+   */
   public double getOctileWeight() {
     return this.octileWeight;
   }
 
+  /**
+   * Returns the weight applied to the perpendicular distance component of the heuristic.
+   *
+   * @return The perpendicular distance weight.
+   */
   public double getPerpendicularWeight() {
     return this.perpendicularWeight;
   }
 
+  /**
+   * Returns the weight applied to the height difference (elevation change) component of the
+   * heuristic.
+   *
+   * @return The height difference weight.
+   */
   public double getHeightWeight() {
     return this.heightWeight;
   }
@@ -96,21 +114,16 @@ public final class HeuristicWeights {
     if (Double.compare(this.getOctileWeight(), other.getOctileWeight()) != 0) return false;
     if (Double.compare(this.getPerpendicularWeight(), other.getPerpendicularWeight()) != 0)
       return false;
-    if (Double.compare(this.getHeightWeight(), other.getHeightWeight()) != 0) return false;
-    return true;
+    return Double.compare(this.getHeightWeight(), other.getHeightWeight()) == 0;
   }
 
   public int hashCode() {
     final int PRIME = 59;
     int result = 1;
-    final long $manhattanWeight = Double.doubleToLongBits(this.getManhattanWeight());
-    result = result * PRIME + (int) ($manhattanWeight >>> 32 ^ $manhattanWeight);
-    final long $octileWeight = Double.doubleToLongBits(this.getOctileWeight());
-    result = result * PRIME + (int) ($octileWeight >>> 32 ^ $octileWeight);
-    final long $perpendicularWeight = Double.doubleToLongBits(this.getPerpendicularWeight());
-    result = result * PRIME + (int) ($perpendicularWeight >>> 32 ^ $perpendicularWeight);
-    final long $heightWeight = Double.doubleToLongBits(this.getHeightWeight());
-    result = result * PRIME + (int) ($heightWeight >>> 32 ^ $heightWeight);
+    result = result * PRIME + Double.hashCode(this.getManhattanWeight());
+    result = result * PRIME + Double.hashCode(this.getOctileWeight());
+    result = result * PRIME + Double.hashCode(this.getPerpendicularWeight());
+    result = result * PRIME + Double.hashCode(this.getHeightWeight());
     return result;
   }
 

--- a/pathetic-api/src/main/java/de/metaphoriker/pathetic/api/pathing/configuration/PathfinderConfiguration.java
+++ b/pathetic-api/src/main/java/de/metaphoriker/pathetic/api/pathing/configuration/PathfinderConfiguration.java
@@ -1,11 +1,12 @@
 package de.metaphoriker.pathetic.api.pathing.configuration;
 
 import de.metaphoriker.pathetic.api.provider.NavigationPointProvider;
+import java.util.Objects;
 
 /**
  * Defines a set of configurable parameters that govern the behavior of the A* pathfinding
  * algorithm. By adjusting these parameters, you can fine-tune the pathfinding process to suit the
- * specific needs of your Minecraft environment.
+ * specific needs of your 3D environment.
  */
 public class PathfinderConfiguration {
 
@@ -13,12 +14,12 @@ public class PathfinderConfiguration {
    * The maximum number of iterations allowed for the pathfinding algorithm. This acts as a
    * safeguard to prevent infinite loops in complex scenarios.
    *
-   * @default 5000
+   * <p>Default: 5000
    */
   private final int maxIterations;
 
   /**
-   * The maximum permissible length of a calculated path (in blocks). Use this to constrain long
+   * The maximum permissible length of a calculated path (in positions). Use this to constrain long
    * searches that could impact performance. A value of 0 indicates no limit.
    */
   private final int maxLength;
@@ -32,15 +33,17 @@ public class PathfinderConfiguration {
 
   /**
    * If pathfinding fails, this parameter determines whether the algorithm should fall back to the
-   * last successfully calculated path. This can help maintain progress, but might use an outdated
-   * path.
+   * last successfully calculated path. This can help maintain progress, but might use an
+   * uncompleted path.
    */
   private final boolean fallback;
 
   /**
    * The provider responsible for supplying navigation points to the pathfinding algorithm. This
-   * provider determines how the pathfinder interacts with the world and accesses information about
-   * valid movement locations.
+   * provider determines how the pathfinder interacts with the environment and accesses information
+   * about positions.
+   *
+   * @see NavigationPointProvider
    */
   private final NavigationPointProvider provider;
 
@@ -48,7 +51,7 @@ public class PathfinderConfiguration {
    * The set of weights used to calculate heuristics within the A* algorithm. These influence the
    * pathfinding priority for distance, elevation changes, smoothness, and diagonal movement.
    *
-   * @default HeuristicWeights.NATURAL_PATH_WEIGHTS
+   * <p>Default: {@link HeuristicWeights#NATURAL_PATH_WEIGHTS}
    */
   private final HeuristicWeights heuristicWeights;
 
@@ -136,7 +139,7 @@ public class PathfinderConfiguration {
     if (o == this) return true;
     if (!(o instanceof PathfinderConfiguration)) return false;
     final PathfinderConfiguration other = (PathfinderConfiguration) o;
-    if (!other.canEqual((Object) this)) return false;
+    if (!other.canEqual(this)) return false;
     if (this.getMaxIterations() != other.getMaxIterations()) return false;
     if (this.getMaxLength() != other.getMaxLength()) return false;
     if (this.isAsync() != other.isAsync()) return false;
@@ -146,10 +149,7 @@ public class PathfinderConfiguration {
         : !this.getProvider().equals(other.getProvider())) return false;
     final Object this$heuristicWeights = this.getHeuristicWeights();
     final Object other$heuristicWeights = other.getHeuristicWeights();
-    if (this$heuristicWeights == null
-        ? other$heuristicWeights != null
-        : !this$heuristicWeights.equals(other$heuristicWeights)) return false;
-    return true;
+    return Objects.equals(this$heuristicWeights, other$heuristicWeights);
   }
 
   protected boolean canEqual(final Object other) {

--- a/pathetic-api/src/main/java/de/metaphoriker/pathetic/api/pathing/filter/PathFilter.java
+++ b/pathetic-api/src/main/java/de/metaphoriker/pathetic/api/pathing/filter/PathFilter.java
@@ -8,9 +8,9 @@ import de.metaphoriker.pathetic.api.pathing.Pathfinder;
  * the pathfinding algorithm's execution.
  *
  * <p>In essence, a PathFilter acts as a whitelist for blocks during the pathfinding process. It
- * evaluates each potential block (or node) on the path and determines whether it is valid or not
- * based on the implemented filter logic. Only the blocks that pass the filter are considered valid
- * and included in the final path.
+ * evaluates each potential position (or node) on the path and determines whether it is valid or not
+ * based on the implemented filter logic. Only the positions that pass the filter are considered
+ * valid and included in the final path.
  */
 @FunctionalInterface
 public interface PathFilter {
@@ -27,7 +27,7 @@ public interface PathFilter {
   /**
    * Cleans up the resources used during the pathfinding process. This method is guaranteed to
    * always be called after pathfinding and should be overridden to ensure proper disposal of
-   * resources. Users can rely on the fact that this method will be invoked post pathfinding to do
+   * resources. Devs can rely on the fact that this method will be invoked post pathfinding to do
    * necessary clean-ups.
    */
   default void cleanup() {}

--- a/pathetic-api/src/main/java/de/metaphoriker/pathetic/api/pathing/filter/PathFilterStage.java
+++ b/pathetic-api/src/main/java/de/metaphoriker/pathetic/api/pathing/filter/PathFilterStage.java
@@ -1,35 +1,55 @@
 package de.metaphoriker.pathetic.api.pathing.filter;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Set;
 
-/** A stage for multiple PathFilters. */
+/**
+ * A stage for processing a collection of {@link PathFilter} instances. This class facilitates the
+ * sequential application of multiple filters to a given pathfinding context.
+ */
 public final class PathFilterStage {
 
   private final Set<PathFilter> filters = new HashSet<>();
 
+  /**
+   * Constructs a {@code PathFilterStage} with an initial set of filters.
+   *
+   * @param pathFilter An array of {@link PathFilter} instances to include in the stage.
+   */
   public PathFilterStage(PathFilter... pathFilter) {
     filters.addAll(Arrays.asList(pathFilter));
   }
 
   /**
-   * Filters the given context with all filters in the stage.
+   * Applies all filters within this stage to the provided {@link PathValidationContext}. Each
+   * filter in the stage is executed sequentially.
    *
-   * @param context The context to filter.
-   * @return true if the context passes all filters, false otherwise.
+   * @param context The {@link PathValidationContext} to be filtered.
+   * @return {@code true} if the context passes all filters in the stage, {@code false} otherwise.
    */
   public boolean filter(PathValidationContext context) {
     return filters.stream().allMatch(filter -> filter.filter(context));
   }
 
-  /** Cleans up all filters in the stage. */
+  /**
+   * Performs cleanup operations on all filters within the stage.
+   *
+   * @see PathFilter#cleanup()
+   */
   public void cleanup() {
     filters.forEach(PathFilter::cleanup);
   }
 
+  /**
+   * Returns an immutable set of the filters currently in this stage.
+   *
+   * @return The set of {@link PathFilter} instances in this stage.
+   */
   public Set<PathFilter> getFilters() {
-    return this.filters;
+    return Collections.unmodifiableSet(filters);
   }
 
   public boolean equals(final Object o) {
@@ -38,9 +58,7 @@ public final class PathFilterStage {
     final PathFilterStage other = (PathFilterStage) o;
     final Object this$filters = this.getFilters();
     final Object other$filters = other.getFilters();
-    if (this$filters == null ? other$filters != null : !this$filters.equals(other$filters))
-      return false;
-    return true;
+    return Objects.equals(this$filters, other$filters);
   }
 
   public int hashCode() {

--- a/pathetic-api/src/main/java/de/metaphoriker/pathetic/api/pathing/filter/PathValidationContext.java
+++ b/pathetic-api/src/main/java/de/metaphoriker/pathetic/api/pathing/filter/PathValidationContext.java
@@ -10,35 +10,10 @@ import java.util.Objects;
  */
 public final class PathValidationContext {
 
-  /**
-   * The current position being evaluated in the pathfinding process. This represents the position
-   * that is being validated by the filter to determine if it can be part of a valid path.
-   */
   private final PathPosition position;
-
-  /**
-   * The parent position of the current position. This is the previous node from which the current
-   * position was reached. It is used to trace the path and ensure logical continuity between nodes.
-   */
   private final PathPosition parent;
-
-  /**
-   * The absolute start position of the pathfinding process. This represents the original starting
-   * point of the path and remains constant throughout the algorithm, providing a stable reference.
-   */
   private final PathPosition absoluteStart;
-
-  /**
-   * The absolute target position of the pathfinding process. This is the final goal or destination
-   * that the pathfinding algorithm is trying to reach. Like the start, it remains constant and
-   * provides a clear end-point for the path.
-   */
   private final PathPosition absoluteTarget;
-
-  /**
-   * The NavigationPointProvider provides access to world data, such as positional information, in
-   * the context of the pathfinding process.
-   */
   private final NavigationPointProvider navigationPointProvider;
 
   public PathValidationContext(
@@ -54,22 +29,43 @@ public final class PathValidationContext {
     this.navigationPointProvider = navigationPointProvider;
   }
 
+  /**
+   * The current position being evaluated in the pathfinding process. This represents the position
+   * that is being validated by the filter to determine if it can be part of a valid path.
+   */
   public PathPosition getPosition() {
     return this.position;
   }
 
+  /**
+   * The parent position of the current position. This is the previous node from which the current
+   * position was reached. It is used to trace the path and ensure logical continuity between nodes.
+   */
   public PathPosition getParent() {
     return this.parent;
   }
 
+  /**
+   * The absolute start position of the pathfinding process. This represents the original starting
+   * point of the path and remains constant throughout the algorithm, providing a stable reference.
+   */
   public PathPosition getAbsoluteStart() {
     return this.absoluteStart;
   }
 
+  /**
+   * The absolute target position of the pathfinding process. This is the final goal or destination
+   * that the pathfinding algorithm is trying to reach. Like the start, it remains constant and
+   * provides a clear end-point for the path.
+   */
   public PathPosition getAbsoluteTarget() {
     return this.absoluteTarget;
   }
 
+  /**
+   * The NavigationPointProvider provides access to world data, such as positional information, in
+   * the context of the pathfinding process.
+   */
   public NavigationPointProvider getNavigationPointProvider() {
     return this.navigationPointProvider;
   }

--- a/pathetic-api/src/main/java/de/metaphoriker/pathetic/api/pathing/filter/PathValidationContext.java
+++ b/pathetic-api/src/main/java/de/metaphoriker/pathetic/api/pathing/filter/PathValidationContext.java
@@ -2,13 +2,11 @@ package de.metaphoriker.pathetic.api.pathing.filter;
 
 import de.metaphoriker.pathetic.api.provider.NavigationPointProvider;
 import de.metaphoriker.pathetic.api.wrapper.PathPosition;
+import java.util.Objects;
 
 /**
  * PathValidationContext is a data container used during the pathfinding process to provide relevant
  * contextual information needed for evaluating path validity.
- *
- * <p>This context is passed to {@link PathFilter#filter} methods during the pathfinding process and
- * allows filters to validate or invalidate nodes based on the provided context.
  */
 public final class PathValidationContext {
 
@@ -38,9 +36,8 @@ public final class PathValidationContext {
   private final PathPosition absoluteTarget;
 
   /**
-   * The BlockProvider provides access to world data, such as block information, in the context of
-   * the pathfinding process. It is used to retrieve block data from the world at different
-   * positions during path validation.
+   * The NavigationPointProvider provides access to world data, such as positional information, in
+   * the context of the pathfinding process.
    */
   private final NavigationPointProvider navigationPointProvider;
 
@@ -83,27 +80,19 @@ public final class PathValidationContext {
     final PathValidationContext other = (PathValidationContext) o;
     final Object this$position = this.getPosition();
     final Object other$position = other.getPosition();
-    if (this$position == null ? other$position != null : !this$position.equals(other$position))
-      return false;
+    if (!Objects.equals(this$position, other$position)) return false;
     final Object this$parent = this.getParent();
     final Object other$parent = other.getParent();
-    if (this$parent == null ? other$parent != null : !this$parent.equals(other$parent))
-      return false;
+    if (!Objects.equals(this$parent, other$parent)) return false;
     final Object this$absoluteStart = this.getAbsoluteStart();
     final Object other$absoluteStart = other.getAbsoluteStart();
-    if (this$absoluteStart == null
-        ? other$absoluteStart != null
-        : !this$absoluteStart.equals(other$absoluteStart)) return false;
+    if (!Objects.equals(this$absoluteStart, other$absoluteStart)) return false;
     final Object this$absoluteTarget = this.getAbsoluteTarget();
     final Object other$absoluteTarget = other.getAbsoluteTarget();
-    if (this$absoluteTarget == null
-        ? other$absoluteTarget != null
-        : !this$absoluteTarget.equals(other$absoluteTarget)) return false;
+    if (!Objects.equals(this$absoluteTarget, other$absoluteTarget)) return false;
     final Object this$blockProvider = this.getNavigationPointProvider();
     final Object other$blockProvider = other.getNavigationPointProvider();
-    if (this$blockProvider == null
-        ? other$blockProvider != null
-        : !this$blockProvider.equals(other$blockProvider)) return false;
+    if (!Objects.equals(this$blockProvider, other$blockProvider)) return false;
     return true;
   }
 

--- a/pathetic-api/src/main/java/de/metaphoriker/pathetic/api/pathing/filter/filters/PassablePathFilter.java
+++ b/pathetic-api/src/main/java/de/metaphoriker/pathetic/api/pathing/filter/filters/PassablePathFilter.java
@@ -1,9 +1,13 @@
 package de.metaphoriker.pathetic.api.pathing.filter.filters;
 
-import de.metaphoriker.pathetic.api.pathing.filter.PathValidationContext;
 import de.metaphoriker.pathetic.api.pathing.filter.PathFilter;
+import de.metaphoriker.pathetic.api.pathing.filter.PathValidationContext;
+import de.metaphoriker.pathetic.api.provider.NavigationPoint;
 
-/** A PathFilter implementation that determines if a path is passable. */
+/** 
+ * A PathFilter implementation that determines if a path is traversable.
+ * {@link NavigationPoint#isTraversable()}
+ */
 public class PassablePathFilter implements PathFilter {
 
   @Override

--- a/pathetic-api/src/main/java/de/metaphoriker/pathetic/api/pathing/hook/PathfindingContext.java
+++ b/pathetic-api/src/main/java/de/metaphoriker/pathetic/api/pathing/hook/PathfindingContext.java
@@ -2,6 +2,8 @@ package de.metaphoriker.pathetic.api.pathing.hook;
 
 import de.metaphoriker.pathetic.api.wrapper.Depth;
 
+import java.util.Objects;
+
 /** Context for the current step of the pathfinding process. */
 public final class PathfindingContext {
 
@@ -22,8 +24,7 @@ public final class PathfindingContext {
     final PathfindingContext other = (PathfindingContext) o;
     final Object this$depth = this.getDepth();
     final Object other$depth = other.getDepth();
-    if (this$depth == null ? other$depth != null : !this$depth.equals(other$depth)) return false;
-    return true;
+    return Objects.equals(this$depth, other$depth);
   }
 
   public int hashCode() {

--- a/pathetic-api/src/main/java/de/metaphoriker/pathetic/api/pathing/result/Path.java
+++ b/pathetic-api/src/main/java/de/metaphoriker/pathetic/api/pathing/result/Path.java
@@ -3,6 +3,11 @@ package de.metaphoriker.pathetic.api.pathing.result;
 import de.metaphoriker.pathetic.api.util.ParameterizedSupplier;
 import de.metaphoriker.pathetic.api.wrapper.PathPosition;
 
+/**
+ * A Path is a sequence of positions that represents a path through a 3D space. The positions are
+ * ordered such that the first position is the start of the path and the last position is the end of
+ * the path. The path may contain additional positions between the start and end positions.
+ */
 public interface Path extends Iterable<PathPosition> {
 
   /**

--- a/pathetic-api/src/main/java/de/metaphoriker/pathetic/api/pathing/result/PathState.java
+++ b/pathetic-api/src/main/java/de/metaphoriker/pathetic/api/pathing/result/PathState.java
@@ -1,5 +1,9 @@
 package de.metaphoriker.pathetic.api.pathing.result;
 
+/**
+ * The state of a finished pathfinding process.
+ * Finished does not mean successful, it just means that the pathfinding process has ended.
+ */
 public enum PathState {
 
   /** The pathfinding process was aborted */

--- a/pathetic-api/src/main/java/de/metaphoriker/pathetic/api/pathing/result/PathfinderResult.java
+++ b/pathetic-api/src/main/java/de/metaphoriker/pathetic/api/pathing/result/PathfinderResult.java
@@ -1,5 +1,11 @@
 package de.metaphoriker.pathetic.api.pathing.result;
 
+/**
+ * The result of a pathfinding operation.
+ *
+ * <p>Pathfinding results are used to encapsulate the outcome of a pathfinding operation. They provide
+ * information about the success of the operation and the resulting path.
+ */
 public interface PathfinderResult {
 
   /**

--- a/pathetic-api/src/main/java/de/metaphoriker/pathetic/api/provider/NavigationPoint.java
+++ b/pathetic-api/src/main/java/de/metaphoriker/pathetic/api/provider/NavigationPoint.java
@@ -6,9 +6,9 @@ package de.metaphoriker.pathetic.api.provider;
 public interface NavigationPoint {
 
   /**
-   * Checks if the block is traversable.
+   * Returns whether the position is traversable or not.
    *
-   * @return true if the block is traversable, false otherwise
+   * @return true if the position is traversable, false otherwise
    */
   boolean isTraversable();
 }

--- a/pathetic-api/src/main/java/de/metaphoriker/pathetic/api/wrapper/EnvironmentHeight.java
+++ b/pathetic-api/src/main/java/de/metaphoriker/pathetic/api/wrapper/EnvironmentHeight.java
@@ -1,0 +1,24 @@
+package de.metaphoriker.pathetic.api.wrapper;
+
+/**
+ * Represents the height range of an environment with defined minimum and maximum bounds.
+ * This class provides methods to access the minimum and maximum height values.
+ */
+public class EnvironmentHeight {
+
+  private final int minHeight;
+  private final int maxHeight;
+
+  public EnvironmentHeight(int minHeight, int maxHeight) {
+    this.minHeight = minHeight;
+    this.maxHeight = maxHeight;
+  }
+
+  public int getMinHeight() {
+    return minHeight;
+  }
+
+  public int getMaxHeight() {
+    return maxHeight;
+  }
+}

--- a/pathetic-api/src/main/java/de/metaphoriker/pathetic/api/wrapper/PathEnvironment.java
+++ b/pathetic-api/src/main/java/de/metaphoriker/pathetic/api/wrapper/PathEnvironment.java
@@ -11,8 +11,7 @@ public final class PathEnvironment {
 
   private final UUID uuid;
   private final String name;
-  private final Integer minHeight;
-  private final Integer maxHeight;
+  private final EnvironmentHeight environmentHeight;
 
   /**
    * Constructs a {@code PathEnvironment} with the specified attributes.
@@ -27,8 +26,7 @@ public final class PathEnvironment {
   public PathEnvironment(UUID uuid, String name, Integer minHeight, Integer maxHeight) {
     this.uuid = uuid;
     this.name = name;
-    this.minHeight = minHeight;
-    this.maxHeight = maxHeight;
+    this.environmentHeight = new EnvironmentHeight(minHeight, maxHeight);
   }
 
   @Override
@@ -50,20 +48,32 @@ public final class PathEnvironment {
     return result;
   }
 
+  /**
+   * Get the unique identifier of this environment.
+   */
   public UUID getUuid() {
     return this.uuid;
   }
 
+  /**
+   * Get the name of this environment.
+   */
   public String getName() {
     return this.name;
   }
 
+  /**
+   * Get the min height of this environment.
+   */
   public Integer getMinHeight() {
-    return this.minHeight;
+    return environmentHeight.getMinHeight();
   }
 
+  /**
+   * Get the max height of this environment.
+   */
   public Integer getMaxHeight() {
-    return this.maxHeight;
+    return environmentHeight.getMaxHeight();
   }
 
   public String toString() {

--- a/pathetic-api/src/main/java/de/metaphoriker/pathetic/api/wrapper/PathEnvironment.java
+++ b/pathetic-api/src/main/java/de/metaphoriker/pathetic/api/wrapper/PathEnvironment.java
@@ -2,7 +2,11 @@ package de.metaphoriker.pathetic.api.wrapper;
 
 import java.util.UUID;
 
-/** Represents the pathing environment */
+/**
+ * Represents the environment in which pathfinding operations take place. This class encapsulates
+ * properties of the environment that can influence pathfinding, such as the environment's unique
+ * identifier, name, and height constraints.
+ */
 public final class PathEnvironment {
 
   private final UUID uuid;
@@ -10,6 +14,16 @@ public final class PathEnvironment {
   private final Integer minHeight;
   private final Integer maxHeight;
 
+  /**
+   * Constructs a {@code PathEnvironment} with the specified attributes.
+   *
+   * @param uuid The unique identifier for this environment.
+   * @param name The name of this environment.
+   * @param minHeight The minimum height within this environment. Can be {@code null} if there is no
+   *     minimum height.
+   * @param maxHeight The maximum height within this environment. Can be {@code null} if there is no
+   *     maximum height.
+   */
   public PathEnvironment(UUID uuid, String name, Integer minHeight, Integer maxHeight) {
     this.uuid = uuid;
     this.name = name;

--- a/pathetic-api/src/main/java/de/metaphoriker/pathetic/api/wrapper/PathPosition.java
+++ b/pathetic-api/src/main/java/de/metaphoriker/pathetic/api/wrapper/PathPosition.java
@@ -3,6 +3,11 @@ package de.metaphoriker.pathetic.api.wrapper;
 import de.metaphoriker.pathetic.api.util.NumberUtils;
 import java.util.Objects;
 
+/**
+ * Represents a position within a {@link PathEnvironment}. This class encapsulates the coordinates
+ * (x, y, z) of a point in the pathfinding environment and provides methods for manipulating and
+ * comparing positions.
+ */
 public class PathPosition implements Cloneable {
 
   private PathEnvironment pathEnvironment;
@@ -11,6 +16,14 @@ public class PathPosition implements Cloneable {
   private double y;
   private double z;
 
+  /**
+   * Constructs a {@code PathPosition} with the specified environment and coordinates.
+   *
+   * @param pathEnvironment The environment this position belongs to.
+   * @param x The x-coordinate of the position.
+   * @param y The y-coordinate of the position.
+   * @param z The z-coordinate of the position.
+   */
   public PathPosition(PathEnvironment pathEnvironment, double x, double y, double z) {
     this.pathEnvironment = pathEnvironment;
     this.x = x;
@@ -19,11 +32,12 @@ public class PathPosition implements Cloneable {
   }
 
   /**
-   * Interpolates between two positions based on the given progress.
+   * Interpolates between this position and another position based on a given progress value.
    *
-   * @param other The other position to interpolate with
-   * @param progress The interpolation progress (0.0 to 1.0)
-   * @return The interpolated position
+   * @param other The other position to interpolate towards.
+   * @param progress The interpolation progress, typically between 0.0 (this position) and 1.0
+   *     (other position).
+   * @return A new {@code PathPosition} representing the interpolated point.
    */
   public PathPosition interpolate(PathPosition other, double progress) {
     double x = NumberUtils.interpolate(this.x, other.x, progress);
@@ -33,10 +47,11 @@ public class PathPosition implements Cloneable {
   }
 
   /**
-   * Checks to see if the two positions are in the same block
+   * Checks if this position and another position are within the same block in the environment.
    *
-   * @param otherPosition The other position to check against
-   * @return True if the positions are in the same block
+   * @param otherPosition The other position to compare with.
+   * @return {@code true} if both positions share the same block coordinates (floored x, y, z
+   *     values), {@code false} otherwise.
    */
   public boolean isInSameBlock(PathPosition otherPosition) {
     return this.getFlooredX() == otherPosition.getFlooredX()
@@ -45,10 +60,11 @@ public class PathPosition implements Cloneable {
   }
 
   /**
-   * Gets the manhattan distance between the current and another position
+   * Calculates the Manhattan distance between this position and another position. Manhattan
+   * distance is the sum of the absolute differences of their coordinates.
    *
-   * @param otherPosition the other {@link PathPosition} to get the distance to
-   * @return the distance
+   * @param otherPosition The other position to calculate the distance to.
+   * @return The Manhattan distance between the two positions.
    */
   public int manhattanDistance(PathPosition otherPosition) {
     return Math.abs(this.getFlooredX() - otherPosition.getFlooredX())
@@ -57,10 +73,12 @@ public class PathPosition implements Cloneable {
   }
 
   /**
-   * Gets the octile distance between the current and another position
+   * Calculates the Octile distance between this position and another position. Octile distance is a
+   * more accurate approximation of diagonal distance in a grid-based environment compared to
+   * Manhattan distance.
    *
-   * @param otherPosition the other {@link PathPosition} to get the distance to
-   * @return the distance
+   * @param otherPosition The other position to calculate the distance to.
+   * @return The Octile distance between the two positions.
    */
   public double octileDistance(PathPosition otherPosition) {
 
@@ -80,9 +98,10 @@ public class PathPosition implements Cloneable {
   }
 
   /**
-   * Gets the distance squared between the current and another position
+   * Calculates the squared distance between this position and another position.
    *
-   * @return The distance squared
+   * @param otherPosition The other position to calculate the distance to.
+   * @return The squared distance between the two positions.
    */
   public double distanceSquared(PathPosition otherPosition) {
     return NumberUtils.square(this.x - otherPosition.x)
@@ -91,128 +110,140 @@ public class PathPosition implements Cloneable {
   }
 
   /**
-   * Gets the distance between the current and another position
+   * Calculates the Euclidean distance between this position and another position.
    *
-   * @return The distance
+   * @param otherPosition The other position to calculate the distance to.
+   * @return The Euclidean distance between the two positions.
    */
   public double distance(PathPosition otherPosition) {
     return NumberUtils.sqrt(this.distanceSquared(otherPosition));
   }
 
   /**
-   * Sets the X coordinate of the {@link PathPosition}
+   * Creates a new {@code PathPosition} with the same environment and coordinates as this one, but
+   * with the x-coordinate set to the given value.
    *
-   * @param x The new X coordinate
-   * @return A new {@link PathPosition}
+   * @param x The new x-coordinate.
+   * @return A new {@code PathPosition} with the updated x-coordinate.
    */
   public PathPosition setX(double x) {
     return new PathPosition(this.pathEnvironment, x, this.y, this.z);
   }
 
   /**
-   * Sets the Y coordinate of the {@link PathPosition}
+   * Creates a new {@code PathPosition} with the same environment and coordinates as this one, but
+   * with the y-coordinate set to the given value.
    *
-   * @param y The new Y coordinate
-   * @return A new {@link PathPosition}
+   * @param y The new y-coordinate.
+   * @return A new {@code PathPosition} with the updated y-coordinate.
    */
   public PathPosition setY(double y) {
     return new PathPosition(this.pathEnvironment, this.x, y, this.z);
   }
 
   /**
-   * Sets the Z coordinate of the {@link PathPosition}
+   * Creates a new {@code PathPosition} with the same environment and coordinates as this one, but
+   * with the z-coordinate set to the given value.
    *
-   * @param z The new Z coordinate
-   * @return A new {@link PathPosition}
+   * @param z The new z-coordinate.
+   * @return A new {@code PathPosition} with the updated z-coordinate.
    */
   public PathPosition setZ(double z) {
     return new PathPosition(this.pathEnvironment, this.x, this.y, z);
   }
 
   /**
-   * Gets the X coordinate of the block the position is in
+   * Returns the x-coordinate of the block this position is located in. This is equivalent to
+   * flooring the x-coordinate.
    *
-   * @return The X coordinate of the block
+   * @return The floored x-coordinate.
    */
   public int getFlooredX() {
     return (int) Math.floor(this.x);
   }
 
   /**
-   * Gets the Y coordinate of the block the position is in
+   * Returns the y-coordinate of the block this position is located in. This is equivalent to
+   * flooring the y-coordinate.
    *
-   * @return The Y coordinate of the block
+   * @return The floored y-coordinate.
    */
   public int getFlooredY() {
     return (int) Math.floor(this.y);
   }
 
   /**
-   * Gets the Z coordinate of the block the position is in
+   * Returns the z-coordinate of the block this position is located in. This is equivalent to
+   * flooring the z-coordinate.
    *
-   * @return The Z coordinate of the block
+   * @return The floored z-coordinate.
    */
   public int getFlooredZ() {
     return (int) Math.floor(this.z);
   }
 
   /**
-   * Adds x,y,z values to the current values
+   * Creates a new {@code PathPosition} by adding the given values to the coordinates of this
+   * position.
    *
-   * @param x The value to add to the x
-   * @param y The value to add to the y
-   * @param z The value to add to the z
-   * @return A new {@link PathPosition}
+   * @param x The value to add to the x-coordinate.
+   * @param y The value to add to the y-coordinate.
+   * @param z The value to add to the z-coordinate.
+   * @return A new {@code PathPosition} with the added values.
    */
   public PathPosition add(final double x, final double y, final double z) {
     return new PathPosition(this.pathEnvironment, this.x + x, this.y + y, this.z + z);
   }
 
   /**
-   * Adds the values of a vector to the position
+   * Creates a new {@code PathPosition} by adding the components of the given vector to the
+   * coordinates of this position.
    *
-   * @param vector The {@link PathVector} who's values will be added
-   * @return A new {@link PathPosition}
+   * @param vector The vector to add.
+   * @return A new {@code PathPosition} with the added vector components.
    */
   public PathPosition add(final PathVector vector) {
     return add(vector.getX(), vector.getY(), vector.getZ());
   }
 
   /**
-   * Subtracts x,y,z values from the current values
+   * Creates a new {@code PathPosition} by subtracting the given values from the coordinates of this
+   * position.
    *
-   * @param x The value to subtract from the x
-   * @param y The value to subtract from the y
-   * @param z The value to subtract from the z
-   * @return A new {@link PathPosition}
+   * @param x The value to subtract from the x-coordinate.
+   * @param y The value to subtract from the y-coordinate.
+   * @param z The value to subtract from the z-coordinate.
+   * @return A new {@code PathPosition} with the subtracted values.
    */
   public PathPosition subtract(final double x, final double y, final double z) {
     return new PathPosition(this.pathEnvironment, this.x - x, this.y - y, this.z - z);
   }
 
   /**
-   * Subtracts the values of a vector from the position
+   * Creates a new {@code PathPosition} by subtracting the components of the given vector from the
+   * coordinates of this position.
    *
-   * @param vector The {@link PathVector} who's values will be subtracted
-   * @return A new {@link PathPosition}
+   * @param vector The vector to subtract.
+   * @return A new {@code PathPosition} with the subtracted vector components.
    */
   public PathPosition subtract(final PathVector vector) {
     return subtract(vector.getX(), vector.getY(), vector.getZ());
   }
 
   /**
-   * Converts the positions x,y,z to a {@link PathVector}
+   * Creates a new {@link PathVector} from the coordinates of this position.
    *
-   * @return A {@link PathVector} of the x,y,z
+   * @return A new {@code PathVector} representing this position's coordinates.
    */
   public PathVector toVector() {
     return new PathVector(this.x, this.y, this.z);
   }
 
   /**
-   * Rounds the x,y,z values to the floor of the values
+   * Creates a new {@code PathPosition} with the same environment, but with the coordinates floored
+   * to the nearest integer values.
    *
-   * @return A new {@link PathPosition}
+   * @return A new {@code PathPosition} with floored coordinates.
    */
   public PathPosition floor() {
     return new PathPosition(
@@ -220,9 +251,10 @@ public class PathPosition implements Cloneable {
   }
 
   /**
-   * Sets the coordinates to the middle of the block
+   * Creates a new {@code PathPosition} with the same environment, but with the coordinates set to
+   * the center of the block they are in.
    *
-   * @return A new {@link PathPosition}
+   * @return A new {@code PathPosition} at the center of the block.
    */
   public PathPosition mid() {
     return new PathPosition(
@@ -233,10 +265,10 @@ public class PathPosition implements Cloneable {
   }
 
   /**
-   * Calculates the midpoint between the current position and the given end position.
+   * Calculates the midpoint between this position and another position.
    *
-   * @param end The end position to calculate the midpoint with
-   * @return A new {@link PathPosition} representing the midpoint
+   * @param end The other position to calculate the midpoint with.
+   * @return A new {@code PathPosition} representing the midpoint.
    */
   public PathPosition midPoint(PathPosition end) {
     return new PathPosition(
@@ -276,18 +308,38 @@ public class PathPosition implements Cloneable {
     return Objects.hash(pathEnvironment, x, y, z);
   }
 
+  /**
+   * Returns the environment this position belongs to.
+   *
+   * @return The {@link PathEnvironment} of this position.
+   */
   public PathEnvironment getPathEnvironment() {
     return this.pathEnvironment;
   }
 
+  /**
+   * Returns the x-coordinate of this position.
+   *
+   * @return The x-coordinate.
+   */
   public double getX() {
     return this.x;
   }
 
+  /**
+   * Returns the y-coordinate of this position.
+   *
+   * @return The y-coordinate.
+   */
   public double getY() {
     return this.y;
   }
 
+  /**
+   * Returns the z-coordinate of this position.
+   *
+   * @return The z-coordinate.
+   */
   public double getZ() {
     return this.z;
   }

--- a/pathetic-api/src/main/java/de/metaphoriker/pathetic/api/wrapper/PathVector.java
+++ b/pathetic-api/src/main/java/de/metaphoriker/pathetic/api/wrapper/PathVector.java
@@ -2,12 +2,24 @@ package de.metaphoriker.pathetic.api.wrapper;
 
 import de.metaphoriker.pathetic.api.util.NumberUtils;
 
+/**
+ * Represents a 3D vector within a pathfinding context. This class encapsulates the x, y, and z
+ * components of a vector and provides methods for vector operations such as addition, subtraction,
+ * dot product, cross product, and normalization.
+ */
 public class PathVector implements Cloneable {
 
   private double x;
   private double y;
   private double z;
 
+  /**
+   * Constructs a {@code PathVector} with the specified x, y, and z components.
+   *
+   * @param x The x-component of the vector.
+   * @param y The y-component of the vector.
+   * @param z The z-component of the vector.
+   */
   public PathVector(double x, double y, double z) {
     this.x = x;
     this.y = y;
@@ -15,12 +27,12 @@ public class PathVector implements Cloneable {
   }
 
   /**
-   * Finds the distance between the line BC and the point A
+   * Computes the distance between a point and a line segment.
    *
-   * @param A The point
-   * @param B The first point of the line
-   * @param C The second point of the line
-   * @return The distance
+   * @param A The point represented as a {@code PathVector}.
+   * @param B The first endpoint of the line segment represented as a {@code PathVector}.
+   * @param C The second endpoint of the line segment represented as a {@code PathVector}.
+   * @return The distance between the point A and the line segment BC.
    */
   public static double computeDistance(PathVector A, PathVector B, PathVector C) {
 
@@ -34,19 +46,19 @@ public class PathVector implements Cloneable {
   }
 
   /**
-   * Calculates the dot product of two vectors
+   * Calculates the dot product of this vector and another vector.
    *
-   * @param otherVector The other vector
-   * @return The dot product
+   * @param otherVector The other vector to calculate the dot product with.
+   * @return The dot product of the two vectors.
    */
   public double dot(PathVector otherVector) {
     return this.x * otherVector.x + this.y * otherVector.y + this.z * otherVector.z;
   }
 
   /**
-   * Gets the length of the {@link PathVector}
+   * Calculates the length (magnitude) of this vector.
    *
-   * @return The length
+   * @return The length of the vector.
    */
   public double length() {
     return Math.sqrt(
@@ -54,10 +66,10 @@ public class PathVector implements Cloneable {
   }
 
   /**
-   * Gets the distance between this vector and another vector
+   * Calculates the Euclidean distance between this vector and another vector.
    *
-   * @param otherVector The other vector
-   * @return The distance
+   * @param otherVector The other vector to calculate the distance to.
+   * @return The distance between the two vectors.
    */
   public double distance(PathVector otherVector) {
     return Math.sqrt(
@@ -67,59 +79,63 @@ public class PathVector implements Cloneable {
   }
 
   /**
-   * Sets the x component of the vector
+   * Creates a new {@code PathVector} with the same y and z components as this vector, but with the
+   * x-component set to the given value.
    *
-   * @param x The x component
-   * @return A new {@link PathVector}
+   * @param x The new x-component.
+   * @return A new {@code PathVector} with the updated x-component.
    */
   public PathVector setX(double x) {
     return new PathVector(x, this.y, this.z);
   }
 
   /**
-   * Sets the y component of the vector
+   * Creates a new {@code PathVector} with the same x and z components as this vector, but with the
+   * y-component set to the given value.
    *
-   * @param y The y component
-   * @return A new {@link PathVector}
+   * @param y The new y-component.
+   * @return A new {@code PathVector} with the updated y-component.
    */
   public PathVector setY(double y) {
     return new PathVector(this.x, y, this.z);
   }
 
   /**
-   * Sets the z component of the vector
+   * Creates a new {@code PathVector} with the same x and y components as this vector, but with the
+   * z-component set to the given value.
    *
-   * @param z The z component
-   * @return A new {@link PathVector}
+   * @param z The new z-component.
+   * @return A new {@code PathVector} with the updated z-component.
    */
   public PathVector setZ(double z) {
     return new PathVector(this.x, this.y, z);
   }
 
   /**
-   * Subtracts one vector from another
+   * Creates a new {@code PathVector} by subtracting another vector from this vector.
    *
-   * @param otherVector {@link PathVector} to vector to subtract from the current Vector
-   * @return A new {@link PathVector}
+   * @param otherVector The vector to subtract from this vector.
+   * @return A new {@code PathVector} representing the difference.
    */
   public PathVector subtract(PathVector otherVector) {
     return new PathVector(this.x - otherVector.x, this.y - otherVector.y, this.z - otherVector.z);
   }
 
   /**
-   * Multiplies itself by a scalar constant
+   * Creates a new {@code PathVector} by multiplying this vector by a scalar value.
    *
-   * @param value The constant to multiply by
-   * @return A new {@link PathVector}
+   * @param value The scalar value to multiply by.
+   * @return A new {@code PathVector} representing the scaled vector.
    */
   public PathVector multiply(double value) {
     return new PathVector(this.x * value, this.y * value, this.z * value);
   }
 
   /**
-   * Normalises the {@link PathVector} (Divides the components by its magnitude)
+   * Creates a new {@code PathVector} by normalizing this vector. Normalization divides each
+   * component of the vector by its magnitude, resulting in a unit vector (length of 1).
    *
-   * @return A new {@link PathVector}
+   * @return A new {@code PathVector} representing the normalized vector.
    */
   public PathVector normalize() {
     double magnitude = this.length();
@@ -127,30 +143,30 @@ public class PathVector implements Cloneable {
   }
 
   /**
-   * Divide the vector by a scalar constant
+   * Creates a new {@code PathVector} by dividing this vector by a scalar value.
    *
-   * @param value The constant to divide by
-   * @return A new {@link PathVector}
+   * @param value The scalar value to divide by.
+   * @return A new {@code PathVector} representing the divided vector.
    */
   public PathVector divide(double value) {
     return new PathVector(this.x / value, this.y / value, this.z / value);
   }
 
   /**
-   * Adds two vectors together
+   * Creates a new {@code PathVector} by adding another vector to this vector.
    *
-   * @param otherVector The other vector
-   * @return A new {@link PathVector}
+   * @param otherVector The vector to add to this vector.
+   * @return A new {@code PathVector} representing the sum.
    */
   public PathVector add(PathVector otherVector) {
     return new PathVector(this.x + otherVector.x, this.y + otherVector.y, this.z + otherVector.z);
   }
 
   /**
-   * Calculates the cross product of two vectors
+   * Calculates the cross product of this vector and another vector.
    *
-   * @param o The other vector
-   * @return The cross product vector
+   * @param o The other vector to calculate the cross product with.
+   * @return A new {@code PathVector} representing the cross product.
    */
   public PathVector getCrossProduct(PathVector o) {
     double x = this.y * o.getZ() - o.getY() * this.z;
@@ -174,14 +190,29 @@ public class PathVector implements Cloneable {
     return clone;
   }
 
+  /**
+   * Returns the x-component of this vector.
+   *
+   * @return The x-component.
+   */
   public double getX() {
     return this.x;
   }
 
+  /**
+   * Returns the y-component of this vector.
+   *
+   * @return The y-component.
+   */
   public double getY() {
     return this.y;
   }
 
+  /**
+   * Returns the z-component of this vector.
+   *
+   * @return The z-component.
+   */
   public double getZ() {
     return this.z;
   }
@@ -190,7 +221,7 @@ public class PathVector implements Cloneable {
     if (o == this) return true;
     if (!(o instanceof PathVector)) return false;
     final PathVector other = (PathVector) o;
-    if (!other.canEqual((Object) this)) return false;
+    if (!other.canEqual(this)) return false;
     if (Double.compare(this.getX(), other.getX()) != 0) return false;
     if (Double.compare(this.getY(), other.getY()) != 0) return false;
     if (Double.compare(this.getZ(), other.getZ()) != 0) return false;

--- a/pathetic-bukkit/pathetic-example/pom.xml
+++ b/pathetic-bukkit/pathetic-example/pom.xml
@@ -7,12 +7,12 @@
     <parent>
         <artifactId>pathetic-main</artifactId>
         <groupId>de.metaphoriker</groupId>
-        <version>4.0</version>
+        <version>4.0.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
     <artifactId>pathetic-example</artifactId>
-    <version>4.0</version>
+    <version>4.0.1</version>
     <packaging>jar</packaging>
 
     <name>pathetic-example</name>
@@ -76,7 +76,7 @@
         <dependency>
             <groupId>de.metaphoriker</groupId>
             <artifactId>pathetic-bukkit</artifactId>
-            <version>4.0</version>
+            <version>4.0.1</version>
         </dependency>
     </dependencies>
 </project>

--- a/pathetic-bukkit/pathetic-example/src/main/java/de/metaphoriker/pathetic/example/command/PatheticCommand.java
+++ b/pathetic-bukkit/pathetic-example/src/main/java/de/metaphoriker/pathetic/example/command/PatheticCommand.java
@@ -116,6 +116,10 @@ public class PatheticCommand implements TabExecutor {
             }
           });
         break;
+
+      default:
+        player.sendMessage("Invalid argument!");
+        return false;
     }
 
     return false;

--- a/pathetic-bukkit/pathetic-provider/paper/pom.xml
+++ b/pathetic-bukkit/pathetic-provider/paper/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>de.metaphoriker</groupId>
         <artifactId>pathetic-main</artifactId>
-        <version>4.0</version>
+        <version>4.0.1</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
 
@@ -30,14 +30,14 @@
         <dependency>
             <groupId>de.metaphoriker</groupId>
             <artifactId>pathetic-api</artifactId>
-            <version>4.0</version>
+            <version>4.0.1</version>
             <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>de.metaphoriker</groupId>
             <artifactId>pathetic-provider</artifactId>
-            <version>4.0</version>
+            <version>4.0.1</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/pathetic-bukkit/pathetic-provider/pom.xml
+++ b/pathetic-bukkit/pathetic-provider/pom.xml
@@ -6,14 +6,14 @@
     <parent>
         <artifactId>pathetic-main</artifactId>
         <groupId>de.metaphoriker</groupId>
-        <version>4.0</version>
+        <version>4.0.1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>pathetic-provider</artifactId>
-    <version>4.0</version>
+    <version>4.0.1</version>
 
     <dependencies>
         <dependency>

--- a/pathetic-bukkit/pathetic-provider/resolver/pom.xml
+++ b/pathetic-bukkit/pathetic-provider/resolver/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>de.metaphoriker</groupId>
         <artifactId>pathetic-main</artifactId>
-        <version>4.0</version>
+        <version>4.0.1</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
 
@@ -35,14 +35,14 @@
         <dependency>
             <groupId>de.metaphoriker</groupId>
             <artifactId>paper</artifactId>
-            <version>4.0</version>
+            <version>4.0.1</version>
             <scope>compile</scope>
         </dependency>
 
         <dependency>
             <groupId>de.metaphoriker</groupId>
             <artifactId>spigot</artifactId>
-            <version>4.0</version>
+            <version>4.0.1</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/pathetic-bukkit/pathetic-provider/spigot/pom.xml
+++ b/pathetic-bukkit/pathetic-provider/spigot/pom.xml
@@ -6,12 +6,12 @@
     <parent>
         <groupId>de.metaphoriker</groupId>
         <artifactId>pathetic-main</artifactId>
-        <version>4.0</version>
+        <version>4.0.1</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
 
     <artifactId>spigot</artifactId>
-    <version>4.0</version>
+    <version>4.0.1</version>
 
     <dependencies>
         <dependency>
@@ -36,119 +36,119 @@
         <dependency>
             <groupId>de.metaphoriker</groupId>
             <artifactId>pathetic-provider</artifactId>
-            <version>4.0</version>
+            <version>4.0.1</version>
             <scope>compile</scope>
         </dependency>
 
         <dependency>
             <groupId>de.metaphoriker</groupId>
             <artifactId>v1_21_R3</artifactId>
-            <version>4.0</version>
+            <version>4.0.1</version>
             <scope>compile</scope>
         </dependency>
 
         <dependency>
             <groupId>de.metaphoriker</groupId>
             <artifactId>v1_21_R2</artifactId>
-            <version>4.0</version>
+            <version>4.0.1</version>
             <scope>compile</scope>
         </dependency>
 
         <dependency>
             <groupId>de.metaphoriker</groupId>
             <artifactId>v1_21_R1</artifactId>
-            <version>4.0</version>
+            <version>4.0.1</version>
             <scope>compile</scope>
         </dependency>
 
         <dependency>
             <groupId>de.metaphoriker</groupId>
             <artifactId>v1_20_R4</artifactId>
-            <version>4.0</version>
+            <version>4.0.1</version>
             <scope>compile</scope>
         </dependency>
 
         <dependency>
             <groupId>de.metaphoriker</groupId>
             <artifactId>v1_20_R3</artifactId>
-            <version>4.0</version>
+            <version>4.0.1</version>
             <scope>compile</scope>
         </dependency>
 
         <dependency>
             <groupId>de.metaphoriker</groupId>
             <artifactId>v1_20_R2</artifactId>
-            <version>4.0</version>
+            <version>4.0.1</version>
             <scope>compile</scope>
         </dependency>
 
         <dependency>
             <groupId>de.metaphoriker</groupId>
             <artifactId>v1_20_R1</artifactId>
-            <version>4.0</version>
+            <version>4.0.1</version>
             <scope>compile</scope>
         </dependency>
 
         <dependency>
             <groupId>de.metaphoriker</groupId>
             <artifactId>v1_19_R3</artifactId>
-            <version>4.0</version>
+            <version>4.0.1</version>
             <scope>compile</scope>
         </dependency>
 
         <dependency>
             <groupId>de.metaphoriker</groupId>
             <artifactId>v1_19_R2</artifactId>
-            <version>4.0</version>
+            <version>4.0.1</version>
             <scope>compile</scope>
         </dependency>
 
         <dependency>
             <groupId>de.metaphoriker</groupId>
             <artifactId>v1_18_R2</artifactId>
-            <version>4.0</version>
+            <version>4.0.1</version>
             <scope>compile</scope>
         </dependency>
 
         <dependency>
             <groupId>de.metaphoriker</groupId>
             <artifactId>v1_18</artifactId>
-            <version>4.0</version>
+            <version>4.0.1</version>
             <scope>compile</scope>
         </dependency>
 
         <dependency>
             <groupId>de.metaphoriker</groupId>
             <artifactId>v1_17</artifactId>
-            <version>4.0</version>
+            <version>4.0.1</version>
             <scope>compile</scope>
         </dependency>
 
         <dependency>
             <groupId>de.metaphoriker</groupId>
             <artifactId>v1_16</artifactId>
-            <version>4.0</version>
+            <version>4.0.1</version>
             <scope>compile</scope>
         </dependency>
 
         <dependency>
             <groupId>de.metaphoriker</groupId>
             <artifactId>v1_15</artifactId>
-            <version>4.0</version>
+            <version>4.0.1</version>
             <scope>compile</scope>
         </dependency>
 
         <dependency>
             <groupId>de.metaphoriker</groupId>
             <artifactId>v1_12</artifactId>
-            <version>4.0</version>
+            <version>4.0.1</version>
             <scope>compile</scope>
         </dependency>
 
         <dependency>
             <groupId>de.metaphoriker</groupId>
             <artifactId>v1_8</artifactId>
-            <version>4.0</version>
+            <version>4.0.1</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/pathetic-bukkit/pathetic-provider/spigot/v1_12/pom.xml
+++ b/pathetic-bukkit/pathetic-provider/spigot/v1_12/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>pathetic-main</artifactId>
         <groupId>de.metaphoriker</groupId>
-        <version>4.0</version>
+        <version>4.0.1</version>
         <relativePath>../../../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>de.metaphoriker</groupId>
             <artifactId>pathetic-provider</artifactId>
-            <version>4.0</version>
+            <version>4.0.1</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/pathetic-bukkit/pathetic-provider/spigot/v1_15/pom.xml
+++ b/pathetic-bukkit/pathetic-provider/spigot/v1_15/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>pathetic-main</artifactId>
         <groupId>de.metaphoriker</groupId>
-        <version>4.0</version>
+        <version>4.0.1</version>
         <relativePath>../../../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>de.metaphoriker</groupId>
             <artifactId>pathetic-provider</artifactId>
-            <version>4.0</version>
+            <version>4.0.1</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/pathetic-bukkit/pathetic-provider/spigot/v1_16/pom.xml
+++ b/pathetic-bukkit/pathetic-provider/spigot/v1_16/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>pathetic-main</artifactId>
         <groupId>de.metaphoriker</groupId>
-        <version>4.0</version>
+        <version>4.0.1</version>
         <relativePath>../../../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>de.metaphoriker</groupId>
             <artifactId>pathetic-provider</artifactId>
-            <version>4.0</version>
+            <version>4.0.1</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/pathetic-bukkit/pathetic-provider/spigot/v1_17/pom.xml
+++ b/pathetic-bukkit/pathetic-provider/spigot/v1_17/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>pathetic-main</artifactId>
         <groupId>de.metaphoriker</groupId>
-        <version>4.0</version>
+        <version>4.0.1</version>
         <relativePath>../../../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>de.metaphoriker</groupId>
             <artifactId>pathetic-provider</artifactId>
-            <version>4.0</version>
+            <version>4.0.1</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/pathetic-bukkit/pathetic-provider/spigot/v1_18/pom.xml
+++ b/pathetic-bukkit/pathetic-provider/spigot/v1_18/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>de.metaphoriker</groupId>
         <artifactId>pathetic-main</artifactId>
-        <version>4.0</version>
+        <version>4.0.1</version>
         <relativePath>../../../../pom.xml</relativePath>
     </parent>
 
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>de.metaphoriker</groupId>
             <artifactId>pathetic-provider</artifactId>
-            <version>4.0</version>
+            <version>4.0.1</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/pathetic-bukkit/pathetic-provider/spigot/v1_18_R2/pom.xml
+++ b/pathetic-bukkit/pathetic-provider/spigot/v1_18_R2/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>de.metaphoriker</groupId>
         <artifactId>pathetic-main</artifactId>
-        <version>4.0</version>
+        <version>4.0.1</version>
         <relativePath>../../../../pom.xml</relativePath>
     </parent>
 
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>de.metaphoriker</groupId>
             <artifactId>pathetic-provider</artifactId>
-            <version>4.0</version>
+            <version>4.0.1</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/pathetic-bukkit/pathetic-provider/spigot/v1_19_R2/pom.xml
+++ b/pathetic-bukkit/pathetic-provider/spigot/v1_19_R2/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>de.metaphoriker</groupId>
         <artifactId>pathetic-main</artifactId>
-        <version>4.0</version>
+        <version>4.0.1</version>
         <relativePath>../../../../pom.xml</relativePath>
     </parent>
 
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>de.metaphoriker</groupId>
             <artifactId>pathetic-provider</artifactId>
-            <version>4.0</version>
+            <version>4.0.1</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/pathetic-bukkit/pathetic-provider/spigot/v1_19_R3/pom.xml
+++ b/pathetic-bukkit/pathetic-provider/spigot/v1_19_R3/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>de.metaphoriker</groupId>
         <artifactId>pathetic-main</artifactId>
-        <version>4.0</version>
+        <version>4.0.1</version>
         <relativePath>../../../../pom.xml</relativePath>
     </parent>
 
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>de.metaphoriker</groupId>
             <artifactId>pathetic-provider</artifactId>
-            <version>4.0</version>
+            <version>4.0.1</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/pathetic-bukkit/pathetic-provider/spigot/v1_20_R1/pom.xml
+++ b/pathetic-bukkit/pathetic-provider/spigot/v1_20_R1/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>de.metaphoriker</groupId>
         <artifactId>pathetic-main</artifactId>
-        <version>4.0</version>
+        <version>4.0.1</version>
         <relativePath>../../../../pom.xml</relativePath>
     </parent>
 
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>de.metaphoriker</groupId>
             <artifactId>pathetic-provider</artifactId>
-            <version>4.0</version>
+            <version>4.0.1</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/pathetic-bukkit/pathetic-provider/spigot/v1_20_R2/pom.xml
+++ b/pathetic-bukkit/pathetic-provider/spigot/v1_20_R2/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>de.metaphoriker</groupId>
         <artifactId>pathetic-main</artifactId>
-        <version>4.0</version>
+        <version>4.0.1</version>
         <relativePath>../../../../pom.xml</relativePath>
     </parent>
 
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>de.metaphoriker</groupId>
             <artifactId>pathetic-provider</artifactId>
-            <version>4.0</version>
+            <version>4.0.1</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/pathetic-bukkit/pathetic-provider/spigot/v1_20_R3/pom.xml
+++ b/pathetic-bukkit/pathetic-provider/spigot/v1_20_R3/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>de.metaphoriker</groupId>
         <artifactId>pathetic-main</artifactId>
-        <version>4.0</version>
+        <version>4.0.1</version>
         <relativePath>../../../../pom.xml</relativePath>
     </parent>
 
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>de.metaphoriker</groupId>
             <artifactId>pathetic-provider</artifactId>
-            <version>4.0</version>
+            <version>4.0.1</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/pathetic-bukkit/pathetic-provider/spigot/v1_20_R4/pom.xml
+++ b/pathetic-bukkit/pathetic-provider/spigot/v1_20_R4/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>de.metaphoriker</groupId>
         <artifactId>pathetic-main</artifactId>
-        <version>4.0</version>
+        <version>4.0.1</version>
         <relativePath>../../../../pom.xml</relativePath>
     </parent>
 
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>de.metaphoriker</groupId>
             <artifactId>pathetic-provider</artifactId>
-            <version>4.0</version>
+            <version>4.0.1</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/pathetic-bukkit/pathetic-provider/spigot/v1_21_R1/pom.xml
+++ b/pathetic-bukkit/pathetic-provider/spigot/v1_21_R1/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>de.metaphoriker</groupId>
         <artifactId>pathetic-main</artifactId>
-        <version>4.0</version>
+        <version>4.0.1</version>
         <relativePath>../../../../pom.xml</relativePath>
     </parent>
 
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>de.metaphoriker</groupId>
             <artifactId>pathetic-provider</artifactId>
-            <version>4.0</version>
+            <version>4.0.1</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/pathetic-bukkit/pathetic-provider/spigot/v1_21_R2/pom.xml
+++ b/pathetic-bukkit/pathetic-provider/spigot/v1_21_R2/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>de.metaphoriker</groupId>
         <artifactId>pathetic-main</artifactId>
-        <version>4.0</version>
+        <version>4.0.1</version>
         <relativePath>../../../../pom.xml</relativePath>
     </parent>
 
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>de.metaphoriker</groupId>
             <artifactId>pathetic-provider</artifactId>
-            <version>4.0</version>
+            <version>4.0.1</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/pathetic-bukkit/pathetic-provider/spigot/v1_21_R3/pom.xml
+++ b/pathetic-bukkit/pathetic-provider/spigot/v1_21_R3/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>de.metaphoriker</groupId>
         <artifactId>pathetic-main</artifactId>
-        <version>4.0</version>
+        <version>4.0.1</version>
         <relativePath>../../../../pom.xml</relativePath>
     </parent>
 
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>de.metaphoriker</groupId>
             <artifactId>pathetic-provider</artifactId>
-            <version>4.0</version>
+            <version>4.0.1</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/pathetic-bukkit/pathetic-provider/spigot/v1_8/pom.xml
+++ b/pathetic-bukkit/pathetic-provider/spigot/v1_8/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>pathetic-main</artifactId>
         <groupId>de.metaphoriker</groupId>
-        <version>4.0</version>
+        <version>4.0.1</version>
         <relativePath>../../../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>de.metaphoriker</groupId>
             <artifactId>pathetic-provider</artifactId>
-            <version>4.0</version>
+            <version>4.0.1</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/pathetic-bukkit/pom.xml
+++ b/pathetic-bukkit/pom.xml
@@ -6,11 +6,11 @@
     <parent>
         <groupId>de.metaphoriker</groupId>
         <artifactId>pathetic-main</artifactId>
-        <version>4.0</version>
+        <version>4.0.1</version>
     </parent>
 
     <artifactId>pathetic-bukkit</artifactId>
-    <version>4.0</version>
+    <version>4.0.1</version>
 
     <dependencies>
         <dependency>
@@ -34,7 +34,7 @@
         <dependency>
             <groupId>de.metaphoriker</groupId>
             <artifactId>pathetic-engine</artifactId>
-            <version>4.0</version>
+            <version>4.0.1</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.google.guava</groupId>
@@ -45,13 +45,13 @@
         <dependency>
             <groupId>de.metaphoriker</groupId>
             <artifactId>resolver</artifactId>
-            <version>4.0</version>
+            <version>4.0.1</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>de.metaphoriker</groupId>
             <artifactId>pathetic-provider</artifactId>
-            <version>4.0</version>
+            <version>4.0.1</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/pathetic-engine/pom.xml
+++ b/pathetic-engine/pom.xml
@@ -162,7 +162,7 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>5.14.2</version>
+            <version>5.15.2</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pathetic-engine/pom.xml
+++ b/pathetic-engine/pom.xml
@@ -6,11 +6,11 @@
     <parent>
         <artifactId>pathetic-main</artifactId>
         <groupId>de.metaphoriker</groupId>
-        <version>4.0</version>
+        <version>4.0.1</version>
     </parent>
 
     <artifactId>pathetic-engine</artifactId>
-    <version>4.0</version>
+    <version>4.0.1</version>
 
     <build>
         <plugins>
@@ -144,7 +144,7 @@
         <dependency>
             <groupId>de.metaphoriker</groupId>
             <artifactId>pathetic-api</artifactId>
-            <version>4.0</version>
+            <version>4.0.1</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/pathetic-engine/src/main/java/de/metaphoriker/pathetic/engine/pathfinder/AStarPathfinder.java
+++ b/pathetic-engine/src/main/java/de/metaphoriker/pathetic/engine/pathfinder/AStarPathfinder.java
@@ -49,6 +49,11 @@ public class AStarPathfinder extends AbstractPathfinder {
     depth.increment();
   }
 
+  @Override
+  protected void cleanup() {
+    gridMap.clear();
+  }
+
   private void evaluateNewNodes(
       FibonacciHeap<Double, Node> nodeQueue,
       Set<PathPosition> examinedPositions,

--- a/pathetic-engine/src/main/java/de/metaphoriker/pathetic/engine/pathfinder/AStarPathfinder.java
+++ b/pathetic-engine/src/main/java/de/metaphoriker/pathetic/engine/pathfinder/AStarPathfinder.java
@@ -188,6 +188,9 @@ public class AStarPathfinder extends AbstractPathfinder {
       if (regionData.getRegionalExaminedPositions().contains(node.getPosition())) {
         return true; // Node is invalid if already examined
       }
+    } else {
+      regionData.getBloomFilter().put(node.getPosition());
+      regionData.getRegionalExaminedPositions().add(node.getPosition());
     }
 
     if (!isWithinWorldBounds(node.getPosition())) {

--- a/pathetic-engine/src/main/java/de/metaphoriker/pathetic/engine/pathfinder/AbstractPathfinder.java
+++ b/pathetic-engine/src/main/java/de/metaphoriker/pathetic/engine/pathfinder/AbstractPathfinder.java
@@ -194,6 +194,7 @@ abstract class AbstractPathfinder implements Pathfinder {
     PathfinderResult pathfinderResult = executePathing(start, target, filters, filterStages);
     filters.forEach(PathFilter::cleanup);
     filterStages.forEach(PathFilterStage::cleanup);
+    cleanup();
     return pathfinderResult;
   }
 
@@ -270,6 +271,12 @@ abstract class AbstractPathfinder implements Pathfinder {
     Collections.reverse(path); // Reverse the path to get the correct order
     return path;
   }
+
+  /**
+   * @deprecated Will be realized in a better way in the future
+   */
+  @Deprecated
+  protected abstract void cleanup();
 
   /** The tick method is called to tick the pathfinding algorithm. */
   protected abstract void tick(

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>de.metaphoriker</groupId>
     <artifactId>pathetic-main</artifactId>
     <packaging>pom</packaging>
-    <version>4.0</version>
+    <version>4.0.1</version>
 
     <properties>
         <maven.compiler.source>8</maven.compiler.source>
@@ -68,7 +68,7 @@
             <dependency>
                 <groupId>de.metaphoriker</groupId>
                 <artifactId>pathetic-api</artifactId>
-                <version>4.0</version>
+                <version>4.0.1</version>
                 <scope>provided</scope>
             </dependency>
         </dependencies>


### PR DESCRIPTION
This PR includes a crucial fix for the examined positions logic within the pathfinder. Now the BloomFilter works as intended and the "just-to-be-sure" check afterwards as well.

GridRegionData is now cleared after every pathfinding attempt with an additional cleanup logic for the pathfinder.