### PR TITLE
Make grid region data concurrent safe

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Special thanks to [@Ollie](https://github.com/olijeffers0n), the co-founder of p
 </p>
 
 <h2>Sponsored By</h2>
-<p>Pathetic is sponsored by JetBrains.
+<p>Pathetic is sponsored by JetBrains. Thank You!
 <br><br>
 
 <img src="https://github.com/user-attachments/assets/262672b9-a673-4732-8392-5771e7aadfd0" alt="JetBrains_beam_logo" width="100"/>

--- a/pathetic-engine/src/main/java/de/metaphoriker/pathetic/engine/util/GridRegionData.java
+++ b/pathetic-engine/src/main/java/de/metaphoriker/pathetic/engine/util/GridRegionData.java
@@ -2,7 +2,7 @@ package de.metaphoriker.pathetic.engine.util;
 
 import com.google.common.hash.BloomFilter;
 import com.google.common.hash.Funnel;
-import java.util.HashSet;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.Set;
 
 import de.metaphoriker.pathetic.api.wrapper.PathPosition;
@@ -49,7 +49,7 @@ public class GridRegionData {
                 .putInt(pathPosition.getFlooredZ());
 
     bloomFilter = BloomFilter.create(pathPositionFunnel, DEFAULT_BLOOM_FILTER_SIZE, DEFAULT_FPP);
-    regionalExaminedPositions = new HashSet<>();
+    regionalExaminedPositions = ConcurrentHashMap.newKeySet();
   }
 
   public BloomFilter<PathPosition> getBloomFilter() {


### PR DESCRIPTION
This resolves a thread safety issue in the AStarPathfinder where multiple threads calling `findPath()` from the same factory instance would cause a ClassCastException. 

The stacktrace:
```
[21:28:42 WARN]: java.lang.ClassCastException: class java.util.HashMap$Node cannot be cast to class java.util.HashMap$TreeNode (java.util.HashMap$Node and java.util.HashMap$TreeNode are in module java.base of loader 'bootstrap')
[21:28:42 WARN]:        at java.base/java.util.HashMap$TreeNode.moveRootToFront(HashMap.java:1994)
[21:28:42 WARN]:        at java.base/java.util.HashMap$TreeNode.putTreeVal(HashMap.java:2173)
[21:28:42 WARN]:        at java.base/java.util.HashMap.putVal(HashMap.java:644)
[21:28:42 WARN]:        at java.base/java.util.HashMap.put(HashMap.java:618)
[21:28:42 WARN]:        at java.base/java.util.HashSet.add(HashSet.java:229)
[21:28:42 WARN]:        at de.metaphoriker.pathetic.engine.pathfinder.AStarPathfinder.isNodeInvalid(AStarPathfinder.java:188)
[21:28:42 WARN]:        at de.metaphoriker.pathetic.engine.pathfinder.AStarPathfinder.isNodeValid(AStarPathfinder.java:78)
[21:28:42 WARN]:        at de.metaphoriker.pathetic.engine.pathfinder.AStarPathfinder.fetchValidNeighbours(AStarPathfinder.java:150)
[21:28:42 WARN]:        at de.metaphoriker.pathetic.engine.pathfinder.AStarPathfinder.evaluateNewNodes(AStarPathfinder.java:64)
[21:28:42 WARN]:        at de.metaphoriker.pathetic.engine.pathfinder.AStarPathfinder.tick(AStarPathfinder.java:49)
[21:28:42 WARN]:        at de.metaphoriker.pathetic.engine.pathfinder.AbstractPathfinder.executePathing(AbstractPathfinder.java:154)
[21:28:42 WARN]:        at de.metaphoriker.pathetic.engine.pathfinder.AbstractPathfinder.executePathingAndCleanupFilters(AbstractPathfinder.java:193)
[21:28:42 WARN]:        at de.metaphoriker.pathetic.engine.pathfinder.AbstractPathfinder.lambda$initiatePathing$0(AbstractPathfinder.java:117)
[21:28:42 WARN]:        at java.base/java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1768)
[21:28:42 WARN]:        at java.base/java.util.concurrent.CompletableFuture$AsyncSupply.exec(CompletableFuture.java:1760)
[21:28:42 WARN]:        at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:387)
[21:28:42 WARN]:        at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1312)
[21:28:42 WARN]:        at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1843)
[21:28:42 WARN]:        at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1808)
[21:28:42 WARN]:        at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:188)
```