### PR TITLE
Fix PathPosition toString formatting

### DIFF
--- a/api/src/main/java/de/bsommerfeld/pathetic/api/wrapper/PathPosition.java
+++ b/api/src/main/java/de/bsommerfeld/pathetic/api/wrapper/PathPosition.java
@@ -328,6 +328,6 @@ public class PathPosition implements Cloneable {
   }
 
   public String toString() {
-    return ", x=" + this.getX() + ", y=" + this.getY() + ", z=" + this.getZ() + ")";
+    return "PathPosition(x=" + this.getX() + ", y=" + this.getY() + ", z=" + this.getZ() + ")";
   }
 }


### PR DESCRIPTION
This fixes the wrong formatting inside the `toString` method of PathPosition caused by commit 089f10ab1c56f8fb801ff082bab6544c92d9b758