### PR TITLE
 Ensure node processor evaluates the initial position

### DIFF
--- a/engine/src/main/java/de/bsommerfeld/pathetic/engine/pathfinder/AbstractPathfinder.java
+++ b/engine/src/main/java/de/bsommerfeld/pathetic/engine/pathfinder/AbstractPathfinder.java
@@ -8,6 +8,7 @@ import de.bsommerfeld.pathetic.api.pathing.hook.PathfindingContext;
 import de.bsommerfeld.pathetic.api.pathing.processing.NodeCostProcessor;
 import de.bsommerfeld.pathetic.api.pathing.processing.NodeValidationProcessor;
 import de.bsommerfeld.pathetic.api.pathing.processing.Processor;
+import de.bsommerfeld.pathetic.api.pathing.processing.context.NodeEvaluationContext;
 import de.bsommerfeld.pathetic.api.pathing.processing.context.SearchContext;
 import de.bsommerfeld.pathetic.api.pathing.result.Path;
 import de.bsommerfeld.pathetic.api.pathing.result.PathState;
@@ -16,6 +17,7 @@ import de.bsommerfeld.pathetic.api.provider.NavigationPointProvider;
 import de.bsommerfeld.pathetic.api.wrapper.Depth;
 import de.bsommerfeld.pathetic.api.wrapper.PathPosition;
 import de.bsommerfeld.pathetic.engine.Node;
+import de.bsommerfeld.pathetic.engine.pathfinder.processing.NodeEvaluationContextImpl;
 import de.bsommerfeld.pathetic.engine.pathfinder.processing.SearchContextImpl;
 import de.bsommerfeld.pathetic.engine.result.PathImpl;
 import de.bsommerfeld.pathetic.engine.result.PathfinderResultImpl;
@@ -161,6 +163,26 @@ public abstract class AbstractPathfinder implements Pathfinder {
       }
 
       Node startNode = createStartNode(start, target);
+
+      final NodeEvaluationContext startNodeContext =
+        new NodeEvaluationContextImpl(
+          searchContext,
+          startNode,
+          null,
+          pathfinderConfiguration.getHeuristicMode());
+
+      if (this.nodeValidationProcessors != null && !this.nodeValidationProcessors.isEmpty()) {
+        final boolean isStartNodeInvalid =
+          this.nodeValidationProcessors
+            .stream()
+            .anyMatch(validator -> !validator.isValid(startNodeContext));
+
+        if (isStartNodeInvalid) {
+          // The start position itself is invalid
+          return new PathfinderResultImpl(PathState.FAILED, new PathImpl(start, target, EMPTY_PATH_POSITIONS));
+        }
+      }
+
       FibonacciHeap<Double, Node> openSet = new FibonacciHeap<>();
       openSet.insert(startNode.getFCost(), startNode);
 


### PR DESCRIPTION
This PR fixes a bug where the `node processor` would skip the evaluation of the initial (start) position of a path.

Previously, this caused a contradiction with the Javadoc for `NodeEvaluationContext.getPreviousPathPosition()`, which stated it would return `null` for the start position. More importantly, it created a functional bug for any node processor that needed to perform logic on the very first node (e.g., caching its position), as the processor would only be invoked starting from the *second* node.

This change ensures the node processor is called for the start node, aligning the behavior with the documentation and fixing the bug for dependent processors.

Logs from the first validation of a node processor:

Before:
```
Parent position: PathPosition(x=0.0, y=47.0, z=-8.0), Current Position: PathPosition(x=-1.0, y=47.0, z=-9.0), Requested Start: PathPosition(x=0.0, y=47.0, z=-8.0)
```

After:
```
Parent position: null, Current Position: PathPosition(x=0.0, y=47.0, z=-8.0), Requested Start: PathPosition(x=0.0, y=47.0, z=-8.0)
```