### PR TITLE
fix: validate transitions when updating existing nodes with better paths

### DIFF
--- a/engine/src/main/java/de/bsommerfeld/pathetic/engine/pathfinder/AStarPathfinder.java
+++ b/engine/src/main/java/de/bsommerfeld/pathetic/engine/pathfinder/AStarPathfinder.java
@@ -106,9 +106,21 @@ public class AStarPathfinder extends AbstractPathfinder {
                 double newGCostForExisting = calculateGCostForSuccessor(nodeEvalContext);
 
                 if (newGCostForExisting < existingNodeInHeap.getGCost()) {
-                    existingNodeInHeap.setParent(currentNode);
-                    existingNodeInHeap.setGCost(newGCostForExisting);
-                    existingHandle.decreaseKey(existingNodeInHeap.getFCost());
+                    boolean isValidByCustomProcessors = true;
+                    if (this.nodeValidationProcessors != null && !this.nodeValidationProcessors.isEmpty()) {
+                        for (final NodeValidationProcessor validator : this.nodeValidationProcessors) {
+                            if (!validator.isValid(nodeEvalContext)) {
+                                isValidByCustomProcessors = false;
+                                break;
+                            }
+                        }
+                    }
+
+                    if (isValidByCustomProcessors) {
+                        existingNodeInHeap.setParent(currentNode);
+                        existingNodeInHeap.setGCost(newGCostForExisting);
+                        existingHandle.decreaseKey(existingNodeInHeap.getFCost());
+                    }
                 }
                 continue; // Already processed or updated in open set
             }


### PR DESCRIPTION
This pull request addresses a bug in the A* pathfinding algorithm where node validation was being skipped when a better path to an existing open set node was discovered. The issue manifested when the pathfinder found multiple routes to the same destination node.

Initially, a node would be added to the open set after proper validation. However, if a subsequent search discovered a cheaper path to that same node, the algorithm would update the parent reference and costs but completely bypass validation for the new transition. This meant that custom node validators would never see certain parent-child relationships that were actually being used in the final computed path.

In practical terms, users would observe situations where their validator logs showed one set of transitions during the search phase, but the final path would contain different parent-child relationships that had never been validated. This could lead to paths that should have been rejected by custom validation logic but were allowed through due to the validation gap.

The fix ensures that whenever an existing node in the open set receives a better parent, the transition is properly validated using the same validation logic applied to newly discovered nodes. If the new transition fails validation, the update is rejected and the original parent relationship is preserved. This maintains the integrity of the pathfinding process while ensuring all transitions in the final path have been properly validated.

![path_expected](https://github.com/user-attachments/assets/0dc0b54d-622e-40ad-b2eb-de94719821a7)
![path_actual_result](https://github.com/user-attachments/assets/eb6566c1-5482-4041-a336-9673bd7dfd34)