### PR TITLE
Expose async executor service to pathfinder config

### DIFF
--- a/api/src/main/java/de/bsommerfeld/pathetic/api/pathing/configuration/PathfinderConfiguration.java
+++ b/api/src/main/java/de/bsommerfeld/pathetic/api/pathing/configuration/PathfinderConfiguration.java
@@ -13,6 +13,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Defines a set of configurable parameters that govern the behavior of the A* pathfinding
@@ -140,10 +142,8 @@ public class PathfinderConfiguration {
   /**
    * The executor service used by the pathfinder to schedule and execute pathfinding requests in case it is marked
    * as {@link PathfinderConfiguration#isAsync()}.
-   * If left as {@code null} the pathfinder implementation is responsible for providing an implementation-dependent
-   * executor service instead.
    */
-  private final ExecutorService asyncExecutorService;
+  private final ExecutorService executorService;
 
   private PathfinderConfiguration(
       int maxIterations,
@@ -161,7 +161,7 @@ public class PathfinderConfiguration {
       IHeuristicStrategy heuristicStrategy,
       boolean reopenClosedNodes,
       List<PathfinderHook> pathfindingHooks,
-      ExecutorService asyncExecutorService) {
+      ExecutorService executorService) {
     this.maxIterations = maxIterations;
     this.maxLength = maxLength;
     this.async = async;
@@ -177,7 +177,7 @@ public class PathfinderConfiguration {
     this.heuristicStrategy = heuristicStrategy;
     this.reopenClosedNodes = reopenClosedNodes;
     this.pathfindingHooks = Collections.unmodifiableList(pathfindingHooks);
-    this.asyncExecutorService = asyncExecutorService;
+    this.executorService = executorService;
   }
 
   /**
@@ -207,7 +207,7 @@ public class PathfinderConfiguration {
         .heuristicStrategy(pathfinderConfiguration.heuristicStrategy)
         .reopenClosedNodes(pathfinderConfiguration.reopenClosedNodes)
         .pathfindingHooks(pathfinderConfiguration.pathfindingHooks)
-        .asyncExecutorService(pathfinderConfiguration.asyncExecutorService)
+        .executorService(pathfinderConfiguration.executorService)
         .build();
   }
 
@@ -275,8 +275,8 @@ public class PathfinderConfiguration {
     return pathfindingHooks;
   }
 
-  public ExecutorService asyncExecutorService() {
-    return asyncExecutorService;
+  public ExecutorService executorService() {
+    return executorService;
   }
 
   @Override
@@ -312,8 +312,8 @@ public class PathfinderConfiguration {
         + reopenClosedNodes
         + ", pathfindingHooks="
         + pathfindingHooks
-        + ", asyncExecutorService="
-        + asyncExecutorService
+        + ", executorService="
+        + executorService
         + '}';
   }
 
@@ -337,7 +337,7 @@ public class PathfinderConfiguration {
         && Objects.equals(neighborStrategy, that.neighborStrategy)
         && heuristicStrategy == that.heuristicStrategy
         && Objects.equals(pathfindingHooks, that.pathfindingHooks)
-        && Objects.equals(asyncExecutorService, that.asyncExecutorService);
+        && Objects.equals(executorService, that.executorService);
   }
 
   @Override
@@ -358,7 +358,7 @@ public class PathfinderConfiguration {
         heuristicStrategy,
         reopenClosedNodes,
         pathfindingHooks,
-        asyncExecutorService
+        executorService
       );
   }
 
@@ -378,7 +378,7 @@ public class PathfinderConfiguration {
     private IHeuristicStrategy heuristicStrategy = HeuristicStrategies.LINEAR;
     private boolean reopenClosedNodes = false;
     private List<PathfinderHook> pathfindingHooks = Collections.emptyList();
-    private ExecutorService asyncExecutorService = null;
+    private ExecutorService executorService = SharedAsyncPathfinderExecutorService.SHARED_PATHING_EXECUTOR_SERVICE;
 
     PathfinderConfigurationBuilder() {}
 
@@ -484,9 +484,9 @@ public class PathfinderConfiguration {
       return this;
     }
 
-    public PathfinderConfiguration.PathfinderConfigurationBuilder asyncExecutorService(
-        ExecutorService asyncExecutorService) {
-      this.asyncExecutorService = asyncExecutorService;
+    public PathfinderConfiguration.PathfinderConfigurationBuilder executorService(
+        ExecutorService executorService) {
+      this.executorService = executorService;
       return this;
     }
 
@@ -507,7 +507,7 @@ public class PathfinderConfiguration {
           this.heuristicStrategy,
           this.reopenClosedNodes,
           this.pathfindingHooks,
-          this.asyncExecutorService);
+          this.executorService);
     }
   }
 }

--- a/api/src/main/java/de/bsommerfeld/pathetic/api/pathing/configuration/PathfinderConfiguration.java
+++ b/api/src/main/java/de/bsommerfeld/pathetic/api/pathing/configuration/PathfinderConfiguration.java
@@ -12,6 +12,7 @@ import de.bsommerfeld.pathetic.api.provider.NavigationPointProvider;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.ExecutorService;
 
 /**
  * Defines a set of configurable parameters that govern the behavior of the A* pathfinding
@@ -136,6 +137,14 @@ public class PathfinderConfiguration {
    */
   private final List<PathfinderHook> pathfindingHooks;
 
+  /**
+   * The executor service used by the pathfinder to schedule and execute pathfinding requests in case it is marked
+   * as {@link PathfinderConfiguration#isAsync()}.
+   * If left as {@code null} the pathfinder implementation is responsible for providing an implementation-dependent
+   * executor service instead.
+   */
+  private final ExecutorService asyncExecutorService;
+
   private PathfinderConfiguration(
       int maxIterations,
       int maxLength,
@@ -151,7 +160,8 @@ public class PathfinderConfiguration {
       double bloomFilterFpp,
       IHeuristicStrategy heuristicStrategy,
       boolean reopenClosedNodes,
-      List<PathfinderHook> pathfindingHooks) {
+      List<PathfinderHook> pathfindingHooks,
+      ExecutorService asyncExecutorService) {
     this.maxIterations = maxIterations;
     this.maxLength = maxLength;
     this.async = async;
@@ -167,6 +177,7 @@ public class PathfinderConfiguration {
     this.heuristicStrategy = heuristicStrategy;
     this.reopenClosedNodes = reopenClosedNodes;
     this.pathfindingHooks = Collections.unmodifiableList(pathfindingHooks);
+    this.asyncExecutorService = asyncExecutorService;
   }
 
   /**
@@ -196,6 +207,7 @@ public class PathfinderConfiguration {
         .heuristicStrategy(pathfinderConfiguration.heuristicStrategy)
         .reopenClosedNodes(pathfinderConfiguration.reopenClosedNodes)
         .pathfindingHooks(pathfinderConfiguration.pathfindingHooks)
+        .asyncExecutorService(pathfinderConfiguration.asyncExecutorService)
         .build();
   }
 
@@ -263,6 +275,10 @@ public class PathfinderConfiguration {
     return pathfindingHooks;
   }
 
+  public ExecutorService asyncExecutorService() {
+    return asyncExecutorService;
+  }
+
   @Override
   public String toString() {
     return "PathfinderConfiguration{"
@@ -296,6 +312,8 @@ public class PathfinderConfiguration {
         + reopenClosedNodes
         + ", pathfindingHooks="
         + pathfindingHooks
+        + ", asyncExecutorService="
+        + asyncExecutorService
         + '}';
   }
 
@@ -318,7 +336,8 @@ public class PathfinderConfiguration {
         && Objects.equals(costProcessors, that.costProcessors)
         && Objects.equals(neighborStrategy, that.neighborStrategy)
         && heuristicStrategy == that.heuristicStrategy
-        && Objects.equals(pathfindingHooks, that.pathfindingHooks);
+        && Objects.equals(pathfindingHooks, that.pathfindingHooks)
+        && Objects.equals(asyncExecutorService, that.asyncExecutorService);
   }
 
   @Override
@@ -338,7 +357,9 @@ public class PathfinderConfiguration {
         bloomFilterFpp,
         heuristicStrategy,
         reopenClosedNodes,
-        pathfindingHooks);
+        pathfindingHooks,
+        asyncExecutorService
+      );
   }
 
   public static class PathfinderConfigurationBuilder {
@@ -357,6 +378,7 @@ public class PathfinderConfiguration {
     private IHeuristicStrategy heuristicStrategy = HeuristicStrategies.LINEAR;
     private boolean reopenClosedNodes = false;
     private List<PathfinderHook> pathfindingHooks = Collections.emptyList();
+    private ExecutorService asyncExecutorService = null;
 
     PathfinderConfigurationBuilder() {}
 
@@ -462,6 +484,12 @@ public class PathfinderConfiguration {
       return this;
     }
 
+    public PathfinderConfiguration.PathfinderConfigurationBuilder asyncExecutorService(
+        ExecutorService asyncExecutorService) {
+      this.asyncExecutorService = asyncExecutorService;
+      return this;
+    }
+
     public PathfinderConfiguration build() {
       return new PathfinderConfiguration(
           this.maxIterations,
@@ -478,7 +506,8 @@ public class PathfinderConfiguration {
           this.bloomFilterFpp,
           this.heuristicStrategy,
           this.reopenClosedNodes,
-          this.pathfindingHooks);
+          this.pathfindingHooks,
+          this.asyncExecutorService);
     }
   }
 }

--- a/api/src/main/java/de/bsommerfeld/pathetic/api/pathing/configuration/SharedAsyncPathfinderExecutorService.java
+++ b/api/src/main/java/de/bsommerfeld/pathetic/api/pathing/configuration/SharedAsyncPathfinderExecutorService.java
@@ -1,0 +1,31 @@
+package de.bsommerfeld.pathetic.api.pathing.configuration;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Internal type to the {@link PathfinderConfiguration} that holds onto the default, shared, executor service used
+ * to dispatch async pathfinding requests.
+ */
+final class SharedAsyncPathfinderExecutorService {
+
+  static final ExecutorService SHARED_PATHING_EXECUTOR_SERVICE =
+    Executors.newWorkStealingPool(Math.max(1, Runtime.getRuntime().availableProcessors() / 2));
+
+  static {
+    Runtime.getRuntime().addShutdownHook(new Thread(SharedAsyncPathfinderExecutorService::shutdownExecutor));
+  }
+
+  private static void shutdownExecutor() {
+    SHARED_PATHING_EXECUTOR_SERVICE.shutdown();
+    try {
+      if (!SHARED_PATHING_EXECUTOR_SERVICE.awaitTermination(5, TimeUnit.SECONDS)) {
+        SHARED_PATHING_EXECUTOR_SERVICE.shutdownNow();
+      }
+    } catch (InterruptedException e) {
+      SHARED_PATHING_EXECUTOR_SERVICE.shutdownNow();
+      Thread.currentThread().interrupt();
+    }
+  }
+}

--- a/engine/src/main/java/de/bsommerfeld/pathetic/engine/pathfinder/AbstractPathfinder.java
+++ b/engine/src/main/java/de/bsommerfeld/pathetic/engine/pathfinder/AbstractPathfinder.java
@@ -65,6 +65,7 @@ public abstract class AbstractPathfinder implements Pathfinder {
   protected final List<ValidationProcessor> validationProcessors;
   protected final List<CostProcessor> costProcessors;
   protected final INeighborStrategy neighborStrategy;
+  protected final ExecutorService asyncExecutorService;
 
   private final Set<PathfinderHook> pathfinderHooks = Collections.synchronizedSet(new HashSet<>());
 
@@ -81,6 +82,7 @@ public abstract class AbstractPathfinder implements Pathfinder {
     this.costProcessors = pathfinderConfiguration.getNodeCostProcessors();
     this.neighborStrategy = pathfinderConfiguration.getNeighborStrategy();
     this.pathfinderHooks.addAll(pathfinderConfiguration.pathfindingHooks());
+    this.asyncExecutorService = pathfinderConfiguration.asyncExecutorService() == null ? PATHING_EXECUTOR_SERVICE : pathfinderConfiguration.asyncExecutorService();
   }
 
   private static void shutdownExecutor() {
@@ -125,7 +127,7 @@ public abstract class AbstractPathfinder implements Pathfinder {
               () ->
                   executePathingAlgorithm(
                       effectiveStart, effectiveTarget, environmentContext, abortFlag),
-              PATHING_EXECUTOR_SERVICE);
+              asyncExecutorService);
     } else {
       future =
           CompletableFuture.completedFuture(

--- a/engine/src/main/java/de/bsommerfeld/pathetic/engine/pathfinder/AbstractPathfinder.java
+++ b/engine/src/main/java/de/bsommerfeld/pathetic/engine/pathfinder/AbstractPathfinder.java
@@ -53,19 +53,13 @@ public abstract class AbstractPathfinder implements Pathfinder {
       Collections.unmodifiableSet(new LinkedHashSet<>(0));
   private static final int INITIAL_CAPACITY = 1024;
   private static final double TIE_BREAKER_WEIGHT = 1e-6;
-  private static final ExecutorService PATHING_EXECUTOR_SERVICE =
-      Executors.newWorkStealingPool(Math.max(1, Runtime.getRuntime().availableProcessors() / 2));
-
-  static {
-    Runtime.getRuntime().addShutdownHook(new Thread(AbstractPathfinder::shutdownExecutor));
-  }
 
   protected final PathfinderConfiguration pathfinderConfiguration;
   protected final NavigationPointProvider navigationPointProvider;
   protected final List<ValidationProcessor> validationProcessors;
   protected final List<CostProcessor> costProcessors;
   protected final INeighborStrategy neighborStrategy;
-  protected final ExecutorService asyncExecutorService;
+  protected final ExecutorService executorService;
 
   private final Set<PathfinderHook> pathfinderHooks = Collections.synchronizedSet(new HashSet<>());
 
@@ -82,19 +76,9 @@ public abstract class AbstractPathfinder implements Pathfinder {
     this.costProcessors = pathfinderConfiguration.getNodeCostProcessors();
     this.neighborStrategy = pathfinderConfiguration.getNeighborStrategy();
     this.pathfinderHooks.addAll(pathfinderConfiguration.pathfindingHooks());
-    this.asyncExecutorService = pathfinderConfiguration.asyncExecutorService() == null ? PATHING_EXECUTOR_SERVICE : pathfinderConfiguration.asyncExecutorService();
-  }
-
-  private static void shutdownExecutor() {
-    PATHING_EXECUTOR_SERVICE.shutdown();
-    try {
-      if (!PATHING_EXECUTOR_SERVICE.awaitTermination(5, TimeUnit.SECONDS)) {
-        PATHING_EXECUTOR_SERVICE.shutdownNow();
-      }
-    } catch (InterruptedException e) {
-      PATHING_EXECUTOR_SERVICE.shutdownNow();
-      Thread.currentThread().interrupt();
-    }
+    this.executorService = Objects.requireNonNull(
+            pathfinderConfiguration.executorService(),
+            "Executor service from configuration has not been set");
   }
 
   @Override
@@ -127,7 +111,7 @@ public abstract class AbstractPathfinder implements Pathfinder {
               () ->
                   executePathingAlgorithm(
                       effectiveStart, effectiveTarget, environmentContext, abortFlag),
-              asyncExecutorService);
+              executorService);
     } else {
       future =
           CompletableFuture.completedFuture(

--- a/engine/src/test/java/de/bsommerfeld/pathetic/engine/pathfinder/AbstractPathfinderTest.java
+++ b/engine/src/test/java/de/bsommerfeld/pathetic/engine/pathfinder/AbstractPathfinderTest.java
@@ -127,7 +127,7 @@ class AbstractPathfinderTest {
       .maxIterations(100)
       .maxLength(50)
       .async(true)
-      .asyncExecutorService(spyedExecutorService)
+      .executorService(spyedExecutorService)
       .build();
 
     final Optional<PathfinderResult> result = new TestPathfinder(configuration).findPath(start, target).result();

--- a/engine/src/test/java/de/bsommerfeld/pathetic/engine/pathfinder/AbstractPathfinderTest.java
+++ b/engine/src/test/java/de/bsommerfeld/pathetic/engine/pathfinder/AbstractPathfinderTest.java
@@ -4,8 +4,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.google.common.util.concurrent.MoreExecutors;
 import de.bsommerfeld.pathetic.api.pathing.PathfindingSearch;
 import de.bsommerfeld.pathetic.api.pathing.configuration.PathfinderConfiguration;
 import de.bsommerfeld.pathetic.api.pathing.context.EnvironmentContext;
@@ -23,7 +26,9 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.BeforeEach;
@@ -112,6 +117,22 @@ class AbstractPathfinderTest {
   void testNullHookNotRegistered() {
     pathfinder.registerPathfindingHook(null);
     assertEquals(0, pathfinder.getRegisteredHooksCount());
+  }
+
+  @Test
+  void testNonSharedExecutorPool() {
+    final ExecutorService spyedExecutorService = Mockito.spy(MoreExecutors.newDirectExecutorService());
+    configuration = PathfinderConfiguration.builder()
+      .provider(mockProvider)
+      .maxIterations(100)
+      .maxLength(50)
+      .async(true)
+      .asyncExecutorService(spyedExecutorService)
+      .build();
+
+    final Optional<PathfinderResult> result = new TestPathfinder(configuration).findPath(start, target).result();
+    assertTrue(result.isPresent());
+    verify(spyedExecutorService, times(1)).execute(any());
   }
 
   /** A concrete implementation of AbstractPathfinder for testing. */


### PR DESCRIPTION
When scheduling pathfinding requests on an async pathfinder, consumers currently have very limited control over the execution of the process as the used executor service is hardcoded. This prevents e.g. naming of the worker threads.

Expose a configuration option in the pathfinder configuration that overrides the executor service used. The option is nullable as the shared pool is not exposed in the API.